### PR TITLE
Fix all remaining blargg APU tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,7 @@ cargo clippy
 - Picture Processing Unit for graphics rendering
 - Implements proper VRAM addressing with internal registers (v, t, x, w)
 - Handles NMI (Non-Maskable Interrupt) generation for VBlank
-- Currently renders the full frame once per VBlank via `gfx::render()` — being migrated
-  to cycle-accurate per-dot rendering
+- Per-dot cycle-accurate rendering
 
 **Memory System (src/emu/memory/)**
 - Memory mappers for different cartridge types (NROM, MMC1, MMC3, UxROM, AxROM, CNROM)
@@ -90,8 +89,7 @@ cargo clippy
 
 **Graphics (src/emu/gfx/)**
 - Frame buffer (`buf.rs`) and palette lookup table (`palette.rs`)
-- `mod.rs` contains the legacy full-frame renderer — will be removed as rendering moves
-  into the PPU
+- `mod.rs` contains the full-frame renderer
 
 **Audio (src/emu/audio.rs)**
 - Audio output handling using rodio crate
@@ -101,8 +99,7 @@ cargo clippy
 **CPU-PPU Synchronization**
 - The emulator runs in discrete cycles, with proper timing between CPU, PPU, and APU
 - PPU runs at 3x CPU speed (3 PPU cycles per CPU cycle)
-- Currently: interleaved per-cycle (CPU instruction, then 3 PPU dots, repeat)
-- Target: catch-up model where PPU syncs lazily on register access
+- Interleaved per-cycle (CPU instruction, then 3 PPU dots, repeat)
 
 **Memory Mapping**
 - Uses trait objects for different mapper implementations
@@ -148,9 +145,8 @@ The project uses both unit tests and integration tests:
 - Proper VRAM address handling with internal registers (v, t, x, w)
 - VBlank timing and NMI generation
 - Scroll register updates at correct cycle points during rendering
-- Current limitation: full-frame rendering at VBlank (no mid-frame raster effects)
+- Per-dot cycle-accurate rendering
 - Sprite 0 hit is approximate (position-based, not pixel-overlap)
-- Active migration to per-dot cycle-accurate rendering
 
 **Memory Mappers**
 - NROM, MMC1, MMC3, UxROM, AxROM, CNROM
@@ -161,12 +157,5 @@ The project uses both unit tests and integration tests:
 - Proper frame counter timing
 - DMC channel with sample playback
 
-The emulator is designed to be highly accurate and passes most standard NES test ROMs, making it suitable for both educational purposes and actual game compatibility testing.
+The emulator passes all standard NES test ROM suites (Klaus2m5, nestest, blargg CPU/PPU/APU/timing, CPU interrupts, PPU OAM, VRAM access).
 
-## Active Work
-
-Migrating PPU from full-frame-at-VBlank rendering to per-dot, catch-up-synchronized
-pipeline. This will enable mid-frame raster effects (split-screen scrolling, scanline
-IRQ-driven effects, sprite 0 hit polling). The migration is incremental across 5 phases
-— each phase produces a working emulator. The old `gfx::render()` path will be removed
-once rendering is fully integrated into the PPU.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Started as a learning-Rust project — a bare 6502 emulator iterating against th
 ## Features
 
 - **MOS 6502 CPU** — all official opcodes plus common unofficial ones (LAX, SAX, DCP, ISB, SLO, SRE, RLA, RRA)
-- **PPU** — per-dot cycle-accurate rendering (active migration from VBlank-based), sprite evaluation, sprite 0 hit, even/odd frame timing
+- **PPU** — per-dot cycle-accurate rendering, sprite evaluation, sprite 0 hit, even/odd frame timing
 - **APU** — pulse, triangle, noise, and DMC channels with IIR high-pass/low-pass filter chain at 44.1 kHz
 - **Mappers** — NROM (0), MMC1 (1), UxROM (2), CNROM (3), MMC3 (4), AxROM (7)
 - **Battery-backed SRAM** — persistent `.sav` files for MMC1/MMC3 cartridges
@@ -99,7 +99,7 @@ round-trips. Integration tests run actual NES test ROMs to validate accuracy:
 
 ```bash
 cargo test              # run all tests
-cargo test -- --ignored # run slow/WIP tests too
+cargo test -- --ignored # run slow tests too
 ```
 
 ### Test ROM suites
@@ -110,8 +110,7 @@ cargo test -- --ignored # run slow/WIP tests too
 | [nestest](http://www.qmtpro.com/~nes/misc/) | CPU instruction correctness (official + unofficial) | Pass |
 | [Blargg CPU](https://github.com/christopherpow/nes-test-roms) | `official_only` — all official opcodes | Pass |
 | Blargg PPU | VBlank basics/set/clear time, NMI control/timing/on/off, VBL suppression, even/odd frames/timing | Pass |
-| Blargg APU | Length counters, length table, IRQ flag | Pass |
-| Blargg APU (strict) | Jitter, len timing, IRQ flag timing, DMC basics, DMC rates | WIP |
+| Blargg APU | Length counters, length table, IRQ flag, jitter, len timing, IRQ flag timing, DMC basics, DMC rates | Pass |
 | Blargg instruction timing | Cycle-accurate instruction timing | Pass |
 | CPU interrupts | NMI and BRK interaction | Pass |
 | PPU OAM | OAM read, OAM stress | Pass |

--- a/src/emu/apu/channels/dmc.rs
+++ b/src/emu/apu/channels/dmc.rs
@@ -1,5 +1,5 @@
 use crate::emu::memory::MemoryMapper;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 pub struct DmcChannel {
     control: u8,
@@ -15,7 +15,11 @@ pub struct DmcChannel {
     // Sample buffer
     sample_buffer: u8,
     sample_buffer_empty: bool,
+
+    // Output unit
+    shift_register: u8,
     bits_remaining: u8,
+    silence: bool,
 
     // Address and length
     current_address: u16,
@@ -38,14 +42,17 @@ impl DmcChannel {
             sample_address: 0,
             sample_length: 0,
 
-            timer: 0,
-            timer_value: 0,
+            timer: DMC_PERIODS[0],
+            timer_value: DMC_PERIODS[0],
 
             enabled: false,
 
             sample_buffer: 0,
             sample_buffer_empty: true,
+
+            shift_register: 0,
             bits_remaining: 0,
+            silence: true,
 
             current_address: 0,
             bytes_remaining: 0,
@@ -63,12 +70,14 @@ impl DmcChannel {
         self.direct_load = 0;
         self.sample_address = 0;
         self.sample_length = 0;
-        self.timer = 0;
-        self.timer_value = 0;
+        self.timer = DMC_PERIODS[0];
+        self.timer_value = DMC_PERIODS[0];
         self.enabled = false;
         self.sample_buffer = 0;
         self.sample_buffer_empty = true;
+        self.shift_register = 0;
         self.bits_remaining = 0;
+        self.silence = true;
         self.current_address = 0;
         self.bytes_remaining = 0;
         self.output_level = 0;
@@ -87,7 +96,9 @@ impl DmcChannel {
         w.write_bool(self.enabled);
         w.write_u8(self.sample_buffer);
         w.write_bool(self.sample_buffer_empty);
+        w.write_u8(self.shift_register);
         w.write_u8(self.bits_remaining);
+        w.write_bool(self.silence);
         w.write_u16(self.current_address);
         w.write_u16(self.bytes_remaining);
         w.write_u8(self.output_level);
@@ -106,7 +117,9 @@ impl DmcChannel {
         self.enabled = r.read_bool()?;
         self.sample_buffer = r.read_u8()?;
         self.sample_buffer_empty = r.read_bool()?;
+        self.shift_register = r.read_u8()?;
         self.bits_remaining = r.read_u8()?;
+        self.silence = r.read_bool()?;
         self.current_address = r.read_u16()?;
         self.bytes_remaining = r.read_u16()?;
         self.output_level = r.read_u8()?;
@@ -121,9 +134,8 @@ impl DmcChannel {
         let irq_enable = (value >> 7) & 1 != 0;
         self.irq_enabled = irq_enable;
         self.timer = DMC_PERIODS[(value & 0x0F) as usize];
-        self.timer_value = self.timer;
         if !irq_enable {
-            self.irq_pending = false; // Clear IRQ flag when disabling IRQ
+            self.irq_pending = false;
         }
     }
 
@@ -158,7 +170,7 @@ impl DmcChannel {
             self.load_sample(memory);
         }
         if self.timer_value == 0 {
-            self.timer_value = self.timer;
+            self.timer_value = self.timer.wrapping_sub(1);
             self.clock_output(memory);
         } else {
             self.timer_value -= 1;
@@ -168,44 +180,32 @@ impl DmcChannel {
         self.generate_output();
     }
 
-    fn clock_output(&mut self, memory: &mut dyn MemoryMapper) {
-        if !self.enabled || self.bytes_remaining == 0 {
-            return;
-        }
-
+    fn clock_output(&mut self, _memory: &mut dyn MemoryMapper) {
         if self.bits_remaining == 0 {
+            self.bits_remaining = 8;
             if self.sample_buffer_empty {
-                self.load_sample(memory);
-            }
-
-            if !self.sample_buffer_empty {
-                self.bits_remaining = 8;
-            }
-        }
-
-        if self.bits_remaining > 0 {
-            let bit = self.sample_buffer & 1;
-            self.sample_buffer >>= 1;
-            self.bits_remaining -= 1;
-
-            if bit == 1 {
-                if self.output_level <= 124 {
-                    self.output_level += 2;
-                } else {
-                    self.output_level = 126;
-                }
+                self.silence = true;
             } else {
-                if self.output_level >= 3 {
-                    self.output_level -= 2;
-                } else {
-                    self.output_level = 1;
-                }
-            }
-
-            if self.bits_remaining == 0 {
+                self.silence = false;
+                self.shift_register = self.sample_buffer;
                 self.sample_buffer_empty = true;
             }
         }
+
+        if !self.silence {
+            if self.shift_register & 1 == 1 {
+                if self.output_level <= 125 {
+                    self.output_level += 2;
+                }
+            } else {
+                if self.output_level >= 2 {
+                    self.output_level -= 2;
+                }
+            }
+            self.shift_register >>= 1;
+        }
+
+        self.bits_remaining -= 1;
     }
 
     fn load_sample(&mut self, memory: &mut dyn MemoryMapper) {
@@ -241,11 +241,6 @@ impl DmcChannel {
     }
 
     fn generate_output(&mut self) {
-        if !self.enabled {
-            self.output = 0.0;
-            return;
-        }
-
         self.output = self.output_level as f32;
     }
 
@@ -310,14 +305,24 @@ mod tests {
         let mut dmc = DmcChannel::new();
         dmc.enabled = true;
         dmc.bytes_remaining = 10;
-        dmc.bits_remaining = 8;
+        dmc.bits_remaining = 1;
+        dmc.silence = false;
+        dmc.shift_register = 0x01;
         dmc.output_level = 64;
+        // sample buffer loaded for next cycle
         dmc.sample_buffer = 0x01;
+        dmc.sample_buffer_empty = false;
         dmc.clock_output(&mut DummyMemory);
+        // bit 0 of 0x01 is 1 → +2, then bits_remaining goes to 0, reloads from buffer
         assert_eq!(dmc.output_level, 66);
+
         dmc.sample_buffer = 0x80;
-        dmc.bits_remaining = 8;
+        dmc.sample_buffer_empty = false;
+        dmc.bits_remaining = 1;
+        dmc.silence = false;
+        dmc.shift_register = 0x80;
         dmc.clock_output(&mut DummyMemory);
+        // bit 0 of 0x80 is 0 → -2
         assert_eq!(dmc.output_level, 64);
     }
 
@@ -328,8 +333,8 @@ mod tests {
         assert_eq!(dmc.direct_load, 0);
         assert_eq!(dmc.sample_address, 0);
         assert_eq!(dmc.sample_length, 0);
-        assert_eq!(dmc.timer, 0);
-        assert_eq!(dmc.timer_value, 0);
+        assert_eq!(dmc.timer, DMC_PERIODS[0]);
+        assert_eq!(dmc.timer_value, DMC_PERIODS[0]);
         assert!(!dmc.enabled);
         assert_eq!(dmc.sample_buffer, 0);
         assert!(dmc.sample_buffer_empty);
@@ -353,9 +358,8 @@ mod tests {
         // Test period setting
         dmc.set_control(0b00001111); // Period 15
         assert_eq!(dmc.timer, DMC_PERIODS[15]);
-
-        // Test that timer value is also set
-        assert_eq!(dmc.timer_value, DMC_PERIODS[15]);
+        // timer_value is NOT reset by set_control (hardware behavior)
+        assert_eq!(dmc.timer_value, DMC_PERIODS[0]);
     }
 
     #[test]
@@ -427,21 +431,20 @@ mod tests {
         let mut dmc = DmcChannel::new();
         let mut mem = DummyMemory;
 
-        // Set up a basic timer
-        dmc.set_control(0x01); // Period 1
+        dmc.set_control(0x01); // Period = DMC_PERIODS[1] = 380
         dmc.enabled = true;
         dmc.bytes_remaining = 10;
+        dmc.timer_value = 0; // Force timer to expire on next cycle
 
-        // Cycle should advance timer
-        let initial_timer = dmc.timer_value;
+        // First cycle: timer_value == 0 → reloads to timer-1=379, calls clock_output
         dmc.cycle(&mut mem);
-        assert_eq!(dmc.timer_value, initial_timer - 1);
+        assert_eq!(dmc.timer_value, dmc.timer - 1);
 
-        // Cycle until timer reaches 0
-        for _ in 0..initial_timer {
+        // Full period = timer cycles: 379 decrements + 1 reload
+        for _ in 0..dmc.timer {
             dmc.cycle(&mut mem);
         }
-        assert_eq!(dmc.timer_value, dmc.timer); // Should reset to timer
+        assert_eq!(dmc.timer_value, dmc.timer - 1);
     }
 
     #[test]
@@ -449,38 +452,39 @@ mod tests {
         let mut dmc = DmcChannel::new();
         let mut mem = DummyMemory;
 
-        // Test when disabled
+        // When bits_remaining is 0 and buffer empty → silence, reload to 8, then decrement to 7
         dmc.clock_output(&mut mem);
-        assert_eq!(dmc.bits_remaining, 0); // Should not change
-
-        // Test when no bytes remaining
-        dmc.enabled = true;
-        dmc.bytes_remaining = 0;
-        dmc.clock_output(&mut mem);
-        assert_eq!(dmc.bits_remaining, 0); // Should not change
-
-        // Test when bits remaining is 0 but sample buffer is empty
-        dmc.bytes_remaining = 10;
-        dmc.bits_remaining = 0;
-        dmc.sample_buffer_empty = true;
-        dmc.current_address = 0xC001; // Set to odd address to get 0xFF sample
-        dmc.clock_output(&mut mem);
-        // Should try to load sample and set bits_remaining to 8, then process a bit (so 7 left)
+        assert!(dmc.silence);
         assert_eq!(dmc.bits_remaining, 7);
-        assert!(!dmc.sample_buffer_empty);
 
-        // Test bit processing (LSB-first: use odd byte so first bit is 1)
-        dmc.sample_buffer = 0x01;
-        dmc.output_level = 64; // Middle level
+        // Load a sample into the buffer, then clock when bits_remaining hits 0
+        dmc.bytes_remaining = 10;
+        dmc.current_address = 0xC001;
+        dmc.sample_buffer_empty = true;
+        // Drain remaining bits in silence
+        for _ in 0..7 {
+            dmc.clock_output(&mut mem);
+        }
+        // Now the cycle() would have filled the buffer; simulate that
+        dmc.sample_buffer = 0xAA;
+        dmc.sample_buffer_empty = false;
+        // bits_remaining is 0 → new output cycle loads buffer into shift register
         dmc.clock_output(&mut mem);
-        assert_eq!(dmc.output_level, 66); // Should increase by 2
-        assert_eq!(dmc.bits_remaining, 6); // Should be 6 after processing one bit
+        assert!(!dmc.silence);
+        assert_eq!(dmc.shift_register, 0xAA >> 1); // shifted once
 
-        // Test bit processing with 0 bit (LSB of 0x02 is 0)
-        dmc.sample_buffer = 0x02;
+        // Test bit processing with known shift register
+        dmc.output_level = 64;
+        dmc.shift_register = 0x01; // bit 0 = 1
+        dmc.silence = false;
+        dmc.bits_remaining = 2;
         dmc.clock_output(&mut mem);
-        assert_eq!(dmc.output_level, 64); // Should decrease by 2
-        assert_eq!(dmc.bits_remaining, 5); // Should be 5 after processing another bit
+        assert_eq!(dmc.output_level, 66); // +2
+
+        dmc.shift_register = 0x02; // bit 0 = 0
+        dmc.bits_remaining = 2;
+        dmc.clock_output(&mut mem);
+        assert_eq!(dmc.output_level, 64); // -2
     }
 
     #[test]
@@ -533,12 +537,10 @@ mod tests {
     fn test_dmc_channel_generate_output() {
         let mut dmc = DmcChannel::new();
 
-        // Test disabled channel
+        // Output always reflects output_level regardless of enabled state
         dmc.generate_output();
         assert_eq!(dmc.output, 0.0);
 
-        // Test enabled channel
-        dmc.enabled = true;
         // Raw 7-bit DAC output to mixer (0–127)
         dmc.output_level = 64;
         dmc.generate_output();
@@ -585,21 +587,36 @@ mod tests {
     #[test]
     fn test_dmc_channel_output_level_bounds() {
         let mut dmc = DmcChannel::new();
-        dmc.enabled = true;
-        dmc.bytes_remaining = 10;
-        dmc.bits_remaining = 8;
 
-        // LSB-first: bit 1 increases toward cap
+        // Bit 1: should not increase past 125 → 127
         dmc.output_level = 126;
-        dmc.sample_buffer = 0x01;
+        dmc.shift_register = 0x01;
+        dmc.silence = false;
+        dmc.bits_remaining = 2;
         dmc.clock_output(&mut DummyMemory);
-        assert_eq!(dmc.output_level, 126); // Should not exceed 126
+        assert_eq!(dmc.output_level, 126); // 126 > 125, no change
 
-        // LSB 0: decrease but clamp at 1
-        dmc.output_level = 1;
-        dmc.sample_buffer = 0x00;
+        dmc.output_level = 125;
+        dmc.shift_register = 0x01;
+        dmc.silence = false;
+        dmc.bits_remaining = 2;
         dmc.clock_output(&mut DummyMemory);
-        assert_eq!(dmc.output_level, 1); // Should not go below 1
+        assert_eq!(dmc.output_level, 127); // 125 + 2 = 127
+
+        // Bit 0: should not decrease below 2 → 0
+        dmc.output_level = 1;
+        dmc.shift_register = 0x00;
+        dmc.silence = false;
+        dmc.bits_remaining = 2;
+        dmc.clock_output(&mut DummyMemory);
+        assert_eq!(dmc.output_level, 1); // 1 < 2, no change
+
+        dmc.output_level = 2;
+        dmc.shift_register = 0x00;
+        dmc.silence = false;
+        dmc.bits_remaining = 2;
+        dmc.clock_output(&mut DummyMemory);
+        assert_eq!(dmc.output_level, 0); // 2 - 2 = 0
     }
 
     #[test]

--- a/src/emu/apu/channels/dmc.rs
+++ b/src/emu/apu/channels/dmc.rs
@@ -171,7 +171,7 @@ impl DmcChannel {
         }
         if self.timer_value == 0 {
             self.timer_value = self.timer.wrapping_sub(1);
-            self.clock_output(memory);
+            self.clock_output();
         } else {
             self.timer_value -= 1;
         }
@@ -180,7 +180,7 @@ impl DmcChannel {
         self.generate_output();
     }
 
-    fn clock_output(&mut self, _memory: &mut dyn MemoryMapper) {
+    fn clock_output(&mut self) {
         if self.bits_remaining == 0 {
             self.bits_remaining = 8;
             if self.sample_buffer_empty {
@@ -312,7 +312,7 @@ mod tests {
         // sample buffer loaded for next cycle
         dmc.sample_buffer = 0x01;
         dmc.sample_buffer_empty = false;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         // bit 0 of 0x01 is 1 → +2, then bits_remaining goes to 0, reloads from buffer
         assert_eq!(dmc.output_level, 66);
 
@@ -321,7 +321,7 @@ mod tests {
         dmc.bits_remaining = 1;
         dmc.silence = false;
         dmc.shift_register = 0x80;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         // bit 0 of 0x80 is 0 → -2
         assert_eq!(dmc.output_level, 64);
     }
@@ -453,7 +453,7 @@ mod tests {
         let mut mem = DummyMemory;
 
         // When bits_remaining is 0 and buffer empty → silence, reload to 8, then decrement to 7
-        dmc.clock_output(&mut mem);
+        dmc.clock_output();
         assert!(dmc.silence);
         assert_eq!(dmc.bits_remaining, 7);
 
@@ -463,13 +463,13 @@ mod tests {
         dmc.sample_buffer_empty = true;
         // Drain remaining bits in silence
         for _ in 0..7 {
-            dmc.clock_output(&mut mem);
+            dmc.clock_output();
         }
         // Now the cycle() would have filled the buffer; simulate that
         dmc.sample_buffer = 0xAA;
         dmc.sample_buffer_empty = false;
         // bits_remaining is 0 → new output cycle loads buffer into shift register
-        dmc.clock_output(&mut mem);
+        dmc.clock_output();
         assert!(!dmc.silence);
         assert_eq!(dmc.shift_register, 0xAA >> 1); // shifted once
 
@@ -478,12 +478,12 @@ mod tests {
         dmc.shift_register = 0x01; // bit 0 = 1
         dmc.silence = false;
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut mem);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 66); // +2
 
         dmc.shift_register = 0x02; // bit 0 = 0
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut mem);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 64); // -2
     }
 
@@ -593,14 +593,14 @@ mod tests {
         dmc.shift_register = 0x01;
         dmc.silence = false;
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 126); // 126 > 125, no change
 
         dmc.output_level = 125;
         dmc.shift_register = 0x01;
         dmc.silence = false;
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 127); // 125 + 2 = 127
 
         // Bit 0: should not decrease below 2 → 0
@@ -608,14 +608,14 @@ mod tests {
         dmc.shift_register = 0x00;
         dmc.silence = false;
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 1); // 1 < 2, no change
 
         dmc.output_level = 2;
         dmc.shift_register = 0x00;
         dmc.silence = false;
         dmc.bits_remaining = 2;
-        dmc.clock_output(&mut DummyMemory);
+        dmc.clock_output();
         assert_eq!(dmc.output_level, 0); // 2 - 2 = 0
     }
 

--- a/src/emu/apu/channels/noise.rs
+++ b/src/emu/apu/channels/noise.rs
@@ -1,4 +1,4 @@
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 pub struct NoiseChannel {
     control: u8,
@@ -165,7 +165,6 @@ impl NoiseChannel {
         // Shift right by 1 and insert feedback at bit 14
         self.shift_register >>= 1;
         self.shift_register |= feedback << 14;
-
     }
 
     fn generate_output(&mut self) {

--- a/src/emu/apu/channels/pulse.rs
+++ b/src/emu/apu/channels/pulse.rs
@@ -1,4 +1,4 @@
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 pub struct PulseChannel {
     channel_index: u8, // 0 for pulse 1, 1 for pulse 2
@@ -730,8 +730,7 @@ mod tests {
         pulse.envelope_decay_level = 5; // Different from volume
         pulse.generate_output();
         assert_eq!(
-            pulse.output,
-            10.0,
+            pulse.output, 10.0,
             "Should use volume in constant volume mode"
         );
 
@@ -739,8 +738,7 @@ mod tests {
         pulse.constant_volume = false;
         pulse.generate_output();
         assert_eq!(
-            pulse.output,
-            5.0,
+            pulse.output, 5.0,
             "Should use envelope decay level in envelope mode"
         );
     }

--- a/src/emu/apu/channels/triangle.rs
+++ b/src/emu/apu/channels/triangle.rs
@@ -1,4 +1,4 @@
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 pub struct TriangleChannel {
     control: u8,

--- a/src/emu/apu/frame_counter.rs
+++ b/src/emu/apu/frame_counter.rs
@@ -1,10 +1,12 @@
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 #[derive(Debug, PartialEq)]
 pub enum FrameStep {
     None,
-    Step(u8),
-    /// $4017 reset finished; if `immediate_clock`, clock length/half/quarter once (5-step entry).
+    QuarterFrame,
+    HalfFrame,
+    Irq,
+    IrqHalfFrame,
     Deferred4017Apply { immediate_clock: bool },
 }
 
@@ -13,16 +15,13 @@ pub struct FrameCounter {
     step: u8,
     cycles: u32,
     irq_inhibit: bool,
-    /// CPU cycles remaining until `pending_write` is applied (see nesdev $4017 delay).
     reset_delay: u8,
     pending_write: u8,
+    block_tick: u8,
 }
 
-/// NTSC 4-step sequence: cycles between quarter/half-frame clocks (sum 29829).
-/// Source: nesdev wiki "APU Frame Counter", confirmed against Mesen2 NesApu.cpp.
-const NTSC_4: [u32; 4] = [7457, 7456, 7458, 7458];
-/// NTSC 5-step sequence (sum 37281).
-const NTSC_5: [u32; 5] = [7457, 7456, 7458, 7458, 7452];
+const MODE0_CYCLES: [u32; 6] = [7457, 14913, 22371, 29828, 29829, 29830];
+const MODE1_CYCLES: [u32; 6] = [7457, 14913, 22371, 29829, 37281, 37282];
 
 impl FrameCounter {
     pub fn new() -> Self {
@@ -33,11 +32,10 @@ impl FrameCounter {
             irq_inhibit: false,
             reset_delay: 0,
             pending_write: 0,
+            block_tick: 0,
         }
     }
 
-    /// Call for $4017 writes. `emu_cycle` should match the global 1:1 CPU cycle counter when the
-    /// write is sampled (even CPU cycle → 3 A cycles delay, odd → 4).
     pub fn write(&mut self, value: u8, emu_cycle: u64) {
         self.irq_inhibit = (value >> 6) & 1 != 0;
         self.pending_write = value;
@@ -52,6 +50,7 @@ impl FrameCounter {
                 self.step = 0;
                 self.cycles = 0;
                 if self.mode == 1 {
+                    self.block_tick = 2;
                     return FrameStep::Deferred4017Apply {
                         immediate_clock: true,
                     };
@@ -61,6 +60,12 @@ impl FrameCounter {
             return FrameStep::None;
         }
 
+        if self.block_tick > 0 {
+            self.block_tick -= 1;
+        }
+
+        self.cycles += 1;
+
         match self.mode {
             0 => self.cycle_mode_0(),
             1 => self.cycle_mode_1(),
@@ -69,28 +74,53 @@ impl FrameCounter {
     }
 
     fn cycle_mode_0(&mut self) -> FrameStep {
-        let period = NTSC_4[self.step as usize];
-        self.cycles += 1;
-        if self.cycles < period {
+        if self.step >= 6 {
             return FrameStep::None;
         }
-        self.cycles = 0;
-        self.step = (self.step + 1) % 4;
-        FrameStep::Step(self.step)
+        let target = MODE0_CYCLES[self.step as usize];
+        if self.cycles < target {
+            return FrameStep::None;
+        }
+        let current_step = self.step;
+        self.step += 1;
+        if self.step >= 6 {
+            self.step = 0;
+            self.cycles = 0;
+        }
+        match current_step {
+            0 | 2 => FrameStep::QuarterFrame,
+            1 => FrameStep::HalfFrame,
+            3 => FrameStep::Irq,
+            4 => FrameStep::IrqHalfFrame,
+            5 => FrameStep::Irq,
+            _ => FrameStep::None,
+        }
     }
 
     fn cycle_mode_1(&mut self) -> FrameStep {
-        let period = NTSC_5[self.step as usize];
-        self.cycles += 1;
-        if self.cycles < period {
+        if self.step >= 6 {
             return FrameStep::None;
         }
-        self.cycles = 0;
-        self.step = (self.step + 1) % 5;
-        if self.step == 0 {
-            FrameStep::None
-        } else {
-            FrameStep::Step(self.step)
+        let target = MODE1_CYCLES[self.step as usize];
+        if self.cycles < target {
+            return FrameStep::None;
+        }
+        let current_step = self.step;
+        self.step += 1;
+        if self.step >= 6 {
+            self.step = 0;
+            self.cycles = 0;
+        }
+
+        if self.block_tick > 0 {
+            return FrameStep::None;
+        }
+
+        match current_step {
+            0 | 2 => FrameStep::QuarterFrame,
+            1 => FrameStep::HalfFrame,
+            4 => FrameStep::HalfFrame,
+            _ => FrameStep::None,
         }
     }
 
@@ -99,6 +129,7 @@ impl FrameCounter {
         self.step
     }
 
+    #[cfg(test)]
     pub fn get_mode(&self) -> u8 {
         self.mode
     }
@@ -114,6 +145,7 @@ impl FrameCounter {
         w.write_bool(self.irq_inhibit);
         w.write_u8(self.reset_delay);
         w.write_u8(self.pending_write);
+        w.write_u8(self.block_tick);
     }
 
     pub fn load_state(&mut self, r: &mut SavestateReader) -> std::io::Result<()> {
@@ -123,6 +155,7 @@ impl FrameCounter {
         self.irq_inhibit = r.read_bool()?;
         self.reset_delay = r.read_u8()?;
         self.pending_write = r.read_u8()?;
+        self.block_tick = r.read_u8()?;
         Ok(())
     }
 }
@@ -159,163 +192,164 @@ mod tests {
     }
 
     #[test]
-    fn test_frame_counter_mode_0_cycle() {
+    fn test_mode_0_quarter_frame_at_7457() {
         let mut fc = FrameCounter::new();
         fc.write(0x00, 0);
+        // Consume the 3-cycle reset delay
+        for _ in 0..3 {
+            assert_eq!(fc.cycle(), FrameStep::None);
+        }
+        // 7456 cycles of nothing
+        for _ in 0..7456 {
+            assert_eq!(fc.cycle(), FrameStep::None);
+        }
+        // Cycle 7457: quarter frame
+        assert_eq!(fc.cycle(), FrameStep::QuarterFrame);
+    }
+
+    #[test]
+    fn test_mode_0_half_frame_at_14913() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x00, 0);
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        for _ in 0..14912 {
+            fc.cycle();
+        }
+        assert_eq!(fc.cycle(), FrameStep::HalfFrame);
+    }
+
+    #[test]
+    fn test_mode_0_irq_window() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x00, 0);
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        // Advance to just before the IRQ window
+        for _ in 0..29827 {
+            fc.cycle();
+        }
+        // Cycle 29828: first IRQ
+        assert_eq!(fc.cycle(), FrameStep::Irq);
+        // Cycle 29829: IRQ + half frame
+        assert_eq!(fc.cycle(), FrameStep::IrqHalfFrame);
+        // Cycle 29830: final IRQ, then reset
+        assert_eq!(fc.cycle(), FrameStep::Irq);
+        // Should now be back at start
+        assert_eq!(fc.step, 0);
+        assert_eq!(fc.cycles, 0);
+    }
+
+    #[test]
+    fn test_mode_0_irq_inhibited() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x40, 0); // IRQ inhibit set
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        for _ in 0..29827 {
+            fc.cycle();
+        }
+        // IRQ events still fire (APU decides whether to act on them)
+        assert_eq!(fc.cycle(), FrameStep::Irq);
+        assert_eq!(fc.cycle(), FrameStep::IrqHalfFrame);
+        assert_eq!(fc.cycle(), FrameStep::Irq);
+    }
+
+    #[test]
+    fn test_mode_0_full_cycle() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x00, 0);
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        // Full sequence: 29830 cycles
+        let mut events = Vec::new();
+        for _ in 0..29830 {
+            let step = fc.cycle();
+            if step != FrameStep::None {
+                events.push(step);
+            }
+        }
+        assert_eq!(events.len(), 6);
+        assert_eq!(events[0], FrameStep::QuarterFrame); // 7457
+        assert_eq!(events[1], FrameStep::HalfFrame); // 14913
+        assert_eq!(events[2], FrameStep::QuarterFrame); // 22371
+        assert_eq!(events[3], FrameStep::Irq); // 29828
+        assert_eq!(events[4], FrameStep::IrqHalfFrame); // 29829
+        assert_eq!(events[5], FrameStep::Irq); // 29830
+    }
+
+    #[test]
+    fn test_mode_1_immediate_clock() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x80, 0);
         for _ in 0..2 {
             assert_eq!(fc.cycle(), FrameStep::None);
         }
+        assert_eq!(
+            fc.cycle(),
+            FrameStep::Deferred4017Apply {
+                immediate_clock: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_mode_1_full_cycle() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x80, 0);
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        let mut events = Vec::new();
+        for _ in 0..37282 {
+            let step = fc.cycle();
+            if step != FrameStep::None {
+                events.push(step);
+            }
+        }
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0], FrameStep::QuarterFrame); // 7457
+        assert_eq!(events[1], FrameStep::HalfFrame); // 14913
+        assert_eq!(events[2], FrameStep::QuarterFrame); // 22371
+        assert_eq!(events[3], FrameStep::HalfFrame); // 37281
+        assert_eq!(fc.step, 0);
+    }
+
+    #[test]
+    fn test_mode_0_wraps_correctly() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x00, 0);
+        for _ in 0..3 {
+            fc.cycle();
+        }
+        // Run through 2 full sequences
+        for _ in 0..29830 * 2 {
+            fc.cycle();
+        }
+        assert_eq!(fc.step, 0);
+        assert_eq!(fc.cycles, 0);
+    }
+
+    #[test]
+    fn test_odd_cycle_write_delay() {
+        let mut fc = FrameCounter::new();
+        fc.write(0x00, 1); // Odd cycle → 4-cycle delay
+        for _ in 0..3 {
+            assert_eq!(fc.cycle(), FrameStep::None);
+        }
+        // 4th cycle: delay expires
         assert_eq!(fc.cycle(), FrameStep::None);
+        // Now counting from 0
         assert_eq!(fc.mode, 0);
-
-        for _ in 0..7456 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(1));
-        assert_eq!(fc.step, 1);
-
-        for _ in 0..7455 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(2));
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(3));
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(0));
         assert_eq!(fc.step, 0);
     }
 
     #[test]
-    fn test_frame_counter_mode_0_irq() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x00, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-
-        for _ in 0..22371 {
-            fc.cycle();
-        }
-        assert_eq!(fc.step, 3);
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(0));
-        assert_eq!(fc.step, 0);
-    }
-
-    #[test]
-    fn test_frame_counter_mode_0_irq_inhibit_still_clocks_step0() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x40, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-
-        for _ in 0..22371 {
-            fc.cycle();
-        }
-        assert_eq!(fc.step, 3);
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(0));
-        assert_eq!(fc.step, 0);
-    }
-
-    #[test]
-    fn test_frame_counter_mode_1_cycle() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x80, 0);
-        for _ in 0..2 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(
-            fc.cycle(),
-            FrameStep::Deferred4017Apply {
-                immediate_clock: true
-            }
-        );
-
-        for _ in 0..7456 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(1));
-
-        for _ in 0..7455 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(2));
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(3));
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(4));
-
-        for _ in 0..7451 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::None);
-        assert_eq!(fc.step, 0);
-    }
-
-    #[test]
-    fn test_frame_counter_mode_1_no_irq() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x80, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        assert_eq!(
-            fc.cycle(),
-            FrameStep::Deferred4017Apply {
-                immediate_clock: true
-            }
-        );
-
-        let mut step_count = 0;
-        for _ in 0..37281 {
-            let result = fc.cycle();
-            if let FrameStep::Step(_) = result {
-                step_count += 1;
-            }
-        }
-        assert_eq!(fc.step, 0);
-        assert_eq!(step_count, 4);
-    }
-
-    #[test]
-    fn test_frame_counter_get_step() {
-        let mut fc = FrameCounter::new();
-
-        fc.write(0x00, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-        for _ in 0..7457 {
-            fc.cycle();
-        }
-        assert_eq!(fc.get_step(), 1);
-    }
-
-    #[test]
-    fn test_frame_counter_get_mode() {
+    fn test_get_mode() {
         let mut fc = FrameCounter::new();
         assert_eq!(fc.get_mode(), 0);
 
@@ -327,56 +361,9 @@ mod tests {
         assert_eq!(fc.get_mode(), 1);
 
         fc.write(0x00, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-        assert_eq!(fc.get_mode(), 0);
-    }
-
-    #[test]
-    fn test_frame_counter_timing_accuracy() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x00, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-
-        for _ in 0..7457 {
-            fc.cycle();
-        }
-        assert_eq!(fc.cycles, 0);
-        assert_eq!(fc.step, 1);
-
-        fc.write(0x00, 0);
-        for _ in 0..2 {
-            fc.cycle();
-        }
-        fc.cycle();
-        for _ in 0..7456 {
-            fc.cycle();
-        }
-        assert_eq!(fc.step, 0);
-    }
-
-    #[test]
-    fn test_frame_counter_mode_1_timing_accuracy() {
-        let mut fc = FrameCounter::new();
-        fc.write(0x80, 0);
         for _ in 0..3 {
             fc.cycle();
         }
-
-        for _ in 0..22371 {
-            fc.cycle();
-        }
-        assert_eq!(fc.step, 3);
-
-        for _ in 0..7457 {
-            assert_eq!(fc.cycle(), FrameStep::None);
-        }
-        assert_eq!(fc.cycle(), FrameStep::Step(4));
-        assert_eq!(fc.cycles, 0);
+        assert_eq!(fc.get_mode(), 0);
     }
 }

--- a/src/emu/apu/mod.rs
+++ b/src/emu/apu/mod.rs
@@ -82,7 +82,7 @@ impl AudioFilter {
 }
 
 use crate::emu::apu::frame_counter::FrameStep;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 use channels::{DmcChannel, NoiseChannel, PulseChannel, TriangleChannel};
 use frame_counter::FrameCounter;
 
@@ -393,46 +393,29 @@ impl APU {
 
     pub fn cycle(&mut self, memory: &mut dyn crate::emu::memory::MemoryMapper) {
         let frame_step = self.frame_counter.cycle();
-        let mode = self.frame_counter.get_mode();
 
         match frame_step {
             FrameStep::Deferred4017Apply { immediate_clock } => {
                 if immediate_clock {
-                    self.pulse1.clock_length_counter();
-                    self.pulse2.clock_length_counter();
-                    self.triangle.clock_length_counter();
-                    self.noise.clock_length_counter();
-
-                    self.pulse1.clock_envelope();
-                    self.pulse2.clock_envelope();
-                    self.noise.clock_envelope();
-
-                    self.triangle.clock_linear_counter();
+                    self.clock_half_frame();
                 }
             }
-            FrameStep::Step(step) => {
-                // Clock envelopes and linear counter on steps 0, 1, 2, 3 (both modes)
-                if step <= 3 {
-                    self.pulse1.clock_envelope();
-                    self.pulse2.clock_envelope();
-                    self.noise.clock_envelope();
-                    self.triangle.clock_linear_counter();
-                }
-                // Clock length counters and sweep on half-frame edges
-                if (mode == 0 && (step == 0 || step == 2))
-                    || (mode == 1 && (step == 1 || step == 3))
-                {
-                    self.pulse1.clock_length_counter();
-                    self.pulse2.clock_length_counter();
-                    self.triangle.clock_length_counter();
-                    self.noise.clock_length_counter();
-
-                    self.pulse1.clock_sweep();
-                    self.pulse2.clock_sweep();
-                }
-                if mode == 0 && step == 0 && !self.frame_counter.irq_inhibit() {
+            FrameStep::QuarterFrame => {
+                self.clock_quarter_frame();
+            }
+            FrameStep::HalfFrame => {
+                self.clock_half_frame();
+            }
+            FrameStep::Irq => {
+                if !self.frame_counter.irq_inhibit() {
                     self.status |= 0x40;
                 }
+            }
+            FrameStep::IrqHalfFrame => {
+                if !self.frame_counter.irq_inhibit() {
+                    self.status |= 0x40;
+                }
+                self.clock_half_frame();
             }
             FrameStep::None => {}
         }
@@ -449,6 +432,23 @@ impl APU {
             self.cycles_since_sample -= CYCLES_PER_SAMPLE;
             self.generate_sample();
         }
+    }
+
+    fn clock_quarter_frame(&mut self) {
+        self.pulse1.clock_envelope();
+        self.pulse2.clock_envelope();
+        self.noise.clock_envelope();
+        self.triangle.clock_linear_counter();
+    }
+
+    fn clock_half_frame(&mut self) {
+        self.clock_quarter_frame();
+        self.pulse1.clock_length_counter();
+        self.pulse2.clock_length_counter();
+        self.triangle.clock_length_counter();
+        self.noise.clock_length_counter();
+        self.pulse1.clock_sweep();
+        self.pulse2.clock_sweep();
     }
 
     fn generate_sample(&mut self) {
@@ -548,6 +548,10 @@ impl APU {
         Ok(())
     }
 
+    pub fn irq_pending(&self) -> bool {
+        (self.status & 0x40 != 0) || self.dmc.get_irq_pending()
+    }
+
     #[allow(dead_code)]
     pub fn clear_irq(&mut self) {
         self.status &= 0xBF; // Clear frame IRQ bit
@@ -609,7 +613,7 @@ mod tests {
 
         // Test pulse1 control
         apu.write(0x4000, 0x3F, 0); // Volume 15, constant volume
-                                 // Test by enabling and checking output behavior
+                                    // Test by enabling and checking output behavior
         apu.write(0x4015, 0x01, 0); // Enable pulse1
         apu.write(0x4002, 0x10, 0); // Set timer low
         apu.write(0x4003, 0x00, 0); // Set timer high
@@ -630,7 +634,7 @@ mod tests {
 
         // Test pulse2 control
         apu.write(0x4004, 0x3F, 0); // Volume 15, constant volume
-                                 // Test by enabling and checking output behavior
+                                    // Test by enabling and checking output behavior
         apu.write(0x4015, 0x02, 0); // Enable pulse2
         apu.write(0x4006, 0x10, 0); // Set timer low
         apu.write(0x4007, 0x00, 0); // Set timer high
@@ -889,8 +893,8 @@ mod tests {
         apu.write(0x4015, 0x01, 0);
         apu.write(0x4000, 0x20, 0); // Volume 0, envelope enabled
 
-        // Cycle through frame counter steps 0, 1, 2, 3 (should clock envelope)
-        for _ in 0..29829 {
+        // Full mode 0 sequence is 29830 cycles
+        for _ in 0..29830 {
             apu.cycle(&mut DummyMemory);
         }
 
@@ -927,5 +931,66 @@ mod tests {
         apu.dmc.set_enabled(false);
         let status = apu.read(0x4015);
         assert_eq!(status & 0x1F, 0x00); // All channels inactive
+    }
+
+    fn run_blargg_apu_rom(rom_path: &str, test_name: &str) {
+        use crate::emu;
+        use crate::emu::io::loader;
+        use crate::util::get_status_str;
+
+        let mut emu = emu::Emulator::new_headless(loader::load_nes(&String::from(rom_path)));
+        emu.cpu.status = 0x34;
+        emu.cpu.sp = 0xfd;
+        emu.toggle_should_trigger_nmi(true);
+        emu.toggle_debug_on_infinite_loop(false);
+        emu.toggle_quiet_mode(true);
+        emu.toggle_verbose_mode(false);
+        emu.run();
+
+        let expected = format!("\n{}\n\nPassed\n", test_name);
+        let buf = get_status_str(&mut emu, 0x6004, 200);
+        let status = emu.mem.cpu_read(0x6000);
+        assert_eq!(0, status, "test status 0x{:02X}: {}", status, buf.trim());
+        assert_eq!(expected, buf);
+    }
+
+    #[test]
+    fn test_blargg_apu_len_ctr() {
+        run_blargg_apu_rom("input/nes/apu/1-len_ctr.nes", "1-len_ctr");
+    }
+
+    #[test]
+    fn test_blargg_apu_len_table() {
+        run_blargg_apu_rom("input/nes/apu/2-len_table.nes", "2-len_table");
+    }
+
+    #[test]
+    fn test_blargg_apu_irq_flag() {
+        run_blargg_apu_rom("input/nes/apu/3-irq_flag.nes", "3-irq_flag");
+    }
+
+    #[test]
+    fn test_blargg_apu_jitter() {
+        run_blargg_apu_rom("input/nes/apu/4-jitter.nes", "4-jitter");
+    }
+
+    #[test]
+    fn test_blargg_apu_len_timing() {
+        run_blargg_apu_rom("input/nes/apu/5-len_timing.nes", "5-len_timing");
+    }
+
+    #[test]
+    fn test_blargg_apu_irq_flag_timing() {
+        run_blargg_apu_rom("input/nes/apu/6-irq_flag_timing.nes", "6-irq_flag_timing");
+    }
+
+    #[test]
+    fn test_blargg_apu_dmc_basics() {
+        run_blargg_apu_rom("input/nes/apu/7-dmc_basics.nes", "7-dmc_basics");
+    }
+
+    #[test]
+    fn test_blargg_apu_dmc_rates() {
+        run_blargg_apu_rom("input/nes/apu/8-dmc_rates.nes", "8-dmc_rates");
     }
 }

--- a/src/emu/cpu/mod.rs
+++ b/src/emu/cpu/mod.rs
@@ -1,5 +1,5 @@
 use super::memory;
-use super::savestate::{SavestateWriter, SavestateReader};
+use super::savestate::{SavestateReader, SavestateWriter};
 
 pub mod opcodes;
 

--- a/src/emu/io/controller.rs
+++ b/src/emu/io/controller.rs
@@ -35,10 +35,18 @@ impl Controller {
         self.status &= !button;
     }
 
-    pub fn save_status(&self) -> u8 { self.status }
-    pub fn save_polls(&self) -> u64 { self.polls }
-    pub fn load_status(&mut self, s: u8) { self.status = s; }
-    pub fn load_polls(&mut self, p: u64) { self.polls = p; }
+    pub fn save_status(&self) -> u8 {
+        self.status
+    }
+    pub fn save_polls(&self) -> u64 {
+        self.polls
+    }
+    pub fn load_status(&mut self, s: u8) {
+        self.status = s;
+    }
+    pub fn load_polls(&mut self, p: u64) {
+        self.polls = p;
+    }
 
     #[allow(dead_code)] // only used in tests
     pub fn is_pressed(&self, button: u8) -> u8 {

--- a/src/emu/io/loader.rs
+++ b/src/emu/io/loader.rs
@@ -102,7 +102,11 @@ impl Loader for InesLoader {
         let mapper = flags >> 4;
         let has_battery = (flags & 0x02) != 0;
         let prg_ram_units = bytes[8];
-        let submapper = if is_nes2_header { (bytes[8] >> 4) & 0x0F } else { 0 };
+        let submapper = if is_nes2_header {
+            (bytes[8] >> 4) & 0x0F
+        } else {
+            0
+        };
         let prg_offset: usize = INES_HEADER_SIZE + (flags & 0b0000_0100) as usize * 512;
         let chr_offset: usize = prg_offset + (num_prg_blocks as usize * PRG_BANK_SIZE);
 
@@ -155,7 +159,9 @@ impl Loader for InesLoader {
 
         println!(
             "Loading {} PRG banks, {} CHR banks, with {} PRG RAM units{}",
-            num_prg_blocks, num_chr_blocks, prg_ram_units,
+            num_prg_blocks,
+            num_chr_blocks,
+            prg_ram_units,
             if has_battery { ", battery-backed" } else { "" }
         );
 

--- a/src/emu/io/mod.rs
+++ b/src/emu/io/mod.rs
@@ -217,8 +217,7 @@ impl ApplicationHandler for PollHandler<'_> {
                         }
                         KeyCode::Digit3 => {
                             if pressed {
-                                self.apu
-                                    .toggle_mute_bit(0x04, "Triangle");
+                                self.apu.toggle_mute_bit(0x04, "Triangle");
                             }
                         }
                         KeyCode::Digit4 => {

--- a/src/emu/memory/mapper/axrom.rs
+++ b/src/emu/memory/mapper/axrom.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::*;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 /*
 AxROM (Mapper 7)
@@ -234,7 +234,9 @@ impl MemoryMapper for AxROMMapper {
         false
     }
 
-    fn mapper_id(&self) -> u8 { 7 }
+    fn mapper_id(&self) -> u8 {
+        7
+    }
 
     fn save_state(&self, w: &mut SavestateWriter) {
         let ram = unsafe { std::slice::from_raw_parts(self.addr_space_ptr, MAX_RAM_SIZE) };

--- a/src/emu/memory/mapper/cnrom.rs
+++ b/src/emu/memory/mapper/cnrom.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::*;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 /*
 CNROM (Mapper 3)
@@ -208,7 +208,9 @@ impl MemoryMapper for CNROMMapper {
         false
     }
 
-    fn mapper_id(&self) -> u8 { 3 }
+    fn mapper_id(&self) -> u8 {
+        3
+    }
 
     fn save_state(&self, w: &mut SavestateWriter) {
         let ram = unsafe { std::slice::from_raw_parts(self.addr_space_ptr, MAX_RAM_SIZE) };

--- a/src/emu/memory/mapper/mmc1.rs
+++ b/src/emu/memory/mapper/mmc1.rs
@@ -1,7 +1,7 @@
 use super::super::super::io;
 use super::super::*;
 use super::*;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 const BANK_SIZE: usize = 16 * 1024;
 const CHR_BANK_SIZE: u16 = 4 * 1024;
@@ -395,7 +395,9 @@ impl MemoryMapper for MMC1Mapper {
         }
     }
 
-    fn mapper_id(&self) -> u8 { 1 }
+    fn mapper_id(&self) -> u8 {
+        1
+    }
 
     fn save_state(&self, w: &mut SavestateWriter) {
         let cpu_ram = unsafe { std::slice::from_raw_parts(self.cpu_ram_ptr, CPU_RAM_SIZE) };
@@ -467,7 +469,8 @@ mod tests {
         chr_banks.push([0; io::loader::CHR_BANK_SIZE as _]);
         chr_banks.push([0; io::loader::CHR_BANK_SIZE as _]);
 
-        let mut mapper: Box<dyn MemoryMapper> = Box::new(MMC1Mapper::new(0, prg_banks, chr_banks, false, None));
+        let mut mapper: Box<dyn MemoryMapper> =
+            Box::new(MMC1Mapper::new(0, prg_banks, chr_banks, false, None));
 
         assert_eq!(mapper.code_start(), 0x4711);
     }

--- a/src/emu/memory/mapper/mod.rs
+++ b/src/emu/memory/mapper/mod.rs
@@ -8,8 +8,8 @@ pub mod uxrom;
 pub const RESET_TARGET_ADDR: u16 = 0xfffc;
 pub const NAMETABLE_ALIGNMENT_BIT: u8 = 0b0000_0001;
 
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
 use crate::emu::io::controller::Controller;
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 fn save_controllers(w: &mut SavestateWriter, controllers: &[Controller; 2]) {
     w.write_u8(controllers[0].save_status());
@@ -18,7 +18,10 @@ fn save_controllers(w: &mut SavestateWriter, controllers: &[Controller; 2]) {
     w.write_u64(controllers[1].save_polls());
 }
 
-fn load_controllers(r: &mut SavestateReader, controllers: &mut [Controller; 2]) -> std::io::Result<()> {
+fn load_controllers(
+    r: &mut SavestateReader,
+    controllers: &mut [Controller; 2],
+) -> std::io::Result<()> {
     controllers[0].load_status(r.read_u8()?);
     controllers[0].load_polls(r.read_u64()?);
     controllers[1].load_status(r.read_u8()?);
@@ -41,8 +44,12 @@ fn load_mirroring(r: &mut SavestateReader) -> std::io::Result<NametableMirror> {
         1 => NametableMirror::Higher,
         2 => NametableMirror::Vertical,
         3 => NametableMirror::Horizontal,
-        v => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData,
-            format!("bad mirroring value: {}", v))),
+        v => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("bad mirroring value: {}", v),
+            ))
+        }
     })
 }
 
@@ -100,35 +107,107 @@ mod tests {
     #[test]
     fn test_mirror_nametable_addr() {
         // Horizontal mirroring: $2000=$2400, $2800=$2C00
-        assert_eq!(mirror_nametable_addr(0x2000, NametableMirror::Horizontal), 0x0000);
-        assert_eq!(mirror_nametable_addr(0x23FF, NametableMirror::Horizontal), 0x03FF);
-        assert_eq!(mirror_nametable_addr(0x2400, NametableMirror::Horizontal), 0x0000);
-        assert_eq!(mirror_nametable_addr(0x27FF, NametableMirror::Horizontal), 0x03FF);
-        assert_eq!(mirror_nametable_addr(0x2800, NametableMirror::Horizontal), 0x0400);
-        assert_eq!(mirror_nametable_addr(0x2BFF, NametableMirror::Horizontal), 0x07FF);
-        assert_eq!(mirror_nametable_addr(0x2C00, NametableMirror::Horizontal), 0x0400);
-        assert_eq!(mirror_nametable_addr(0x2FFF, NametableMirror::Horizontal), 0x07FF);
+        assert_eq!(
+            mirror_nametable_addr(0x2000, NametableMirror::Horizontal),
+            0x0000
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x23FF, NametableMirror::Horizontal),
+            0x03FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2400, NametableMirror::Horizontal),
+            0x0000
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x27FF, NametableMirror::Horizontal),
+            0x03FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2800, NametableMirror::Horizontal),
+            0x0400
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2BFF, NametableMirror::Horizontal),
+            0x07FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2C00, NametableMirror::Horizontal),
+            0x0400
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2FFF, NametableMirror::Horizontal),
+            0x07FF
+        );
 
         // Vertical mirroring: $2000=$2800, $2400=$2C00
-        assert_eq!(mirror_nametable_addr(0x2000, NametableMirror::Vertical), 0x0000);
-        assert_eq!(mirror_nametable_addr(0x23FF, NametableMirror::Vertical), 0x03FF);
-        assert_eq!(mirror_nametable_addr(0x2400, NametableMirror::Vertical), 0x0400);
-        assert_eq!(mirror_nametable_addr(0x27FF, NametableMirror::Vertical), 0x07FF);
-        assert_eq!(mirror_nametable_addr(0x2800, NametableMirror::Vertical), 0x0000);
-        assert_eq!(mirror_nametable_addr(0x2BFF, NametableMirror::Vertical), 0x03FF);
-        assert_eq!(mirror_nametable_addr(0x2C00, NametableMirror::Vertical), 0x0400);
-        assert_eq!(mirror_nametable_addr(0x2FFF, NametableMirror::Vertical), 0x07FF);
+        assert_eq!(
+            mirror_nametable_addr(0x2000, NametableMirror::Vertical),
+            0x0000
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x23FF, NametableMirror::Vertical),
+            0x03FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2400, NametableMirror::Vertical),
+            0x0400
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x27FF, NametableMirror::Vertical),
+            0x07FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2800, NametableMirror::Vertical),
+            0x0000
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2BFF, NametableMirror::Vertical),
+            0x03FF
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2C00, NametableMirror::Vertical),
+            0x0400
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2FFF, NametableMirror::Vertical),
+            0x07FF
+        );
 
         // Lower: all nametables map to first physical page (0x000-0x3FF)
-        assert_eq!(mirror_nametable_addr(0x2123, NametableMirror::Lower), 0x0123);
-        assert_eq!(mirror_nametable_addr(0x2523, NametableMirror::Lower), 0x0123);
-        assert_eq!(mirror_nametable_addr(0x2923, NametableMirror::Lower), 0x0123);
-        assert_eq!(mirror_nametable_addr(0x2D23, NametableMirror::Lower), 0x0123);
+        assert_eq!(
+            mirror_nametable_addr(0x2123, NametableMirror::Lower),
+            0x0123
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2523, NametableMirror::Lower),
+            0x0123
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2923, NametableMirror::Lower),
+            0x0123
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2D23, NametableMirror::Lower),
+            0x0123
+        );
 
         // Higher: all nametables map to second physical page (0x400-0x7FF)
-        assert_eq!(mirror_nametable_addr(0x2123, NametableMirror::Higher), 0x0523);
-        assert_eq!(mirror_nametable_addr(0x2523, NametableMirror::Higher), 0x0523);
-        assert_eq!(mirror_nametable_addr(0x2923, NametableMirror::Higher), 0x0523);
-        assert_eq!(mirror_nametable_addr(0x2D23, NametableMirror::Higher), 0x0523);
+        assert_eq!(
+            mirror_nametable_addr(0x2123, NametableMirror::Higher),
+            0x0523
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2523, NametableMirror::Higher),
+            0x0523
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2923, NametableMirror::Higher),
+            0x0523
+        );
+        assert_eq!(
+            mirror_nametable_addr(0x2D23, NametableMirror::Higher),
+            0x0523
+        );
     }
 }

--- a/src/emu/memory/mapper/nrom.rs
+++ b/src/emu/memory/mapper/nrom.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::*;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 /*
 All Banks are fixed,
@@ -184,7 +184,9 @@ impl MemoryMapper for NROMMapper {
         false
     }
 
-    fn mapper_id(&self) -> u8 { 0 }
+    fn mapper_id(&self) -> u8 {
+        0
+    }
 
     fn save_state(&self, w: &mut SavestateWriter) {
         let ram = unsafe { std::slice::from_raw_parts(self.addr_space_ptr, MAX_RAM_SIZE) };

--- a/src/emu/memory/mapper/uxrom.rs
+++ b/src/emu/memory/mapper/uxrom.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::*;
-use crate::emu::savestate::{SavestateWriter, SavestateReader};
+use crate::emu::savestate::{SavestateReader, SavestateWriter};
 
 /*
 UxROM (Mapper 2)
@@ -212,7 +212,9 @@ impl MemoryMapper for UxROMMapper {
         false
     }
 
-    fn mapper_id(&self) -> u8 { 2 }
+    fn mapper_id(&self) -> u8 {
+        2
+    }
 
     fn save_state(&self, w: &mut SavestateWriter) {
         let ram = unsafe { std::slice::from_raw_parts(self.addr_space_ptr, MAX_RAM_SIZE) };

--- a/src/emu/mod.rs
+++ b/src/emu/mod.rs
@@ -16,8 +16,6 @@ use std::time::Instant;
 
 use self::audio::{AudioBackend, AudioOutput, SilentAudioOutput};
 
-
-
 #[derive(PartialEq)]
 pub enum CycleState {
     CpuAhead,
@@ -225,14 +223,23 @@ impl Emulator {
         println!("State loaded from {}", path);
     }
 
-    fn load_state_from_reader(&mut self, r: &mut savestate::SavestateReader) -> std::io::Result<()> {
+    fn load_state_from_reader(
+        &mut self,
+        r: &mut savestate::SavestateReader,
+    ) -> std::io::Result<()> {
         self.cpu.load_state(r)?;
         self.ppu.load_state(r)?;
         self.apu.load_state(r)?;
         let mapper_id = r.read_u8()?;
         if mapper_id != self.mem.mapper_id() {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData,
-                format!("mapper mismatch: save={} current={}", mapper_id, self.mem.mapper_id())));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "mapper mismatch: save={} current={}",
+                    mapper_id,
+                    self.mem.mapper_id()
+                ),
+            ));
         }
         self.mem.load_state(r)?;
         self.cycles = r.read_u64()?;
@@ -315,7 +322,8 @@ impl Emulator {
                 let penultimate = actual_cycles.saturating_sub(2);
                 self.irq_sample_deadline = self.instruction_start_dot + penultimate * 3 + 1;
 
-                if i_flag_before && !self.cpu.interrupt_flag()
+                if i_flag_before
+                    && !self.cpu.interrupt_flag()
                     && (opcode == opcodes::CLI || opcode == opcodes::PLP)
                 {
                     self.irq_inhibit_one = true;
@@ -346,7 +354,9 @@ impl Emulator {
         }
         // ~1000 Hz input polling (1,789,773 CPU Hz / 1790 ≈ 1 ms)
         if self.cycles % 1790 == 0 {
-            let result = self.iohandler.poll(&mut *self.mem, &mut self.apu, &mut self.cpu);
+            let result = self
+                .iohandler
+                .poll(&mut *self.mem, &mut self.apu, &mut self.cpu);
             if result.exit {
                 state = CycleState::Exiting;
             }
@@ -483,6 +493,11 @@ impl Emulator {
         }
 
         if self.mem.poll_irq() && self.mem.poll_irq_at_dot(self.irq_sample_deadline) {
+            self.trigger_irq();
+            return true;
+        }
+
+        if self.apu.irq_pending() {
             self.trigger_irq();
             return true;
         }
@@ -1182,7 +1197,8 @@ impl Emulator {
                 } else {
                     self.ppu.get_current_vram_addr()
                 };
-                self.mem.ppu_a12_transition(ppu_addr, self.ppu.last_synced_dot);
+                self.mem
+                    .ppu_a12_transition(ppu_addr, self.ppu.last_synced_dot);
             }
         } else if addr == ppu::OAM_DMA {
             if self.cpu.cycle < self.ppu_register_warmup_until_cpu_cycle {
@@ -1196,7 +1212,9 @@ impl Emulator {
             }
         } else if (0x4000..=0x4017).contains(&addr) && addr != ppu::OAM_DMA {
             let apu_cycle_tag = if addr == 0x4017 {
-                self.cpu.cycle.wrapping_add(u64::from(self.cpu_bus_cycle_offset))
+                self.cpu
+                    .cycle
+                    .wrapping_add(u64::from(self.cpu_bus_cycle_offset))
             } else {
                 0
             };

--- a/src/emu/savestate.rs
+++ b/src/emu/savestate.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 const MAGIC: &[u8; 4] = b"KRNK";
-const VERSION: u8 = 1;
+const VERSION: u8 = 2;
 
 pub struct SavestateWriter {
     buf: Vec<u8>,

--- a/src/emu/savestate.rs
+++ b/src/emu/savestate.rs
@@ -9,27 +9,47 @@ pub struct SavestateWriter {
 
 impl SavestateWriter {
     pub fn new() -> Self {
-        let mut w = Self { buf: Vec::with_capacity(64 * 1024) };
+        let mut w = Self {
+            buf: Vec::with_capacity(64 * 1024),
+        };
         w.buf.extend_from_slice(MAGIC);
         w.buf.push(VERSION);
         w
     }
 
-    pub fn write_u8(&mut self, v: u8) { self.buf.push(v); }
-    pub fn write_u16(&mut self, v: u16) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    pub fn write_u32(&mut self, v: u32) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    pub fn write_u64(&mut self, v: u64) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    pub fn write_i8(&mut self, v: i8) { self.buf.push(v as u8); }
-    pub fn write_f32(&mut self, v: f32) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    pub fn write_f64(&mut self, v: f64) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    pub fn write_bool(&mut self, v: bool) { self.buf.push(v as u8); }
+    pub fn write_u8(&mut self, v: u8) {
+        self.buf.push(v);
+    }
+    pub fn write_u16(&mut self, v: u16) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    pub fn write_u32(&mut self, v: u32) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    pub fn write_u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    pub fn write_i8(&mut self, v: i8) {
+        self.buf.push(v as u8);
+    }
+    pub fn write_f32(&mut self, v: f32) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    pub fn write_f64(&mut self, v: f64) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    pub fn write_bool(&mut self, v: bool) {
+        self.buf.push(v as u8);
+    }
 
     pub fn write_bytes(&mut self, data: &[u8]) {
         self.write_u32(data.len() as u32);
         self.buf.extend_from_slice(data);
     }
 
-    pub fn finish(self) -> Vec<u8> { self.buf }
+    pub fn finish(self) -> Vec<u8> {
+        self.buf
+    }
 }
 
 pub struct SavestateReader<'a> {
@@ -40,21 +60,32 @@ pub struct SavestateReader<'a> {
 impl<'a> SavestateReader<'a> {
     pub fn new(data: &'a [u8]) -> io::Result<Self> {
         if data.len() < 5 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "savestate too short"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "savestate too short",
+            ));
         }
         if &data[0..4] != MAGIC {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "bad savestate magic"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bad savestate magic",
+            ));
         }
         if data[4] != VERSION {
-            return Err(io::Error::new(io::ErrorKind::InvalidData,
-                format!("savestate version {} != expected {}", data[4], VERSION)));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("savestate version {} != expected {}", data[4], VERSION),
+            ));
         }
         Ok(Self { data, pos: 5 })
     }
 
     fn need(&self, n: usize) -> io::Result<()> {
         if self.pos + n > self.data.len() {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "savestate truncated"))
+            Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "savestate truncated",
+            ))
         } else {
             Ok(())
         }
@@ -69,21 +100,21 @@ impl<'a> SavestateReader<'a> {
 
     pub fn read_u16(&mut self) -> io::Result<u16> {
         self.need(2)?;
-        let v = u16::from_le_bytes(self.data[self.pos..self.pos+2].try_into().unwrap());
+        let v = u16::from_le_bytes(self.data[self.pos..self.pos + 2].try_into().unwrap());
         self.pos += 2;
         Ok(v)
     }
 
     pub fn read_u32(&mut self) -> io::Result<u32> {
         self.need(4)?;
-        let v = u32::from_le_bytes(self.data[self.pos..self.pos+4].try_into().unwrap());
+        let v = u32::from_le_bytes(self.data[self.pos..self.pos + 4].try_into().unwrap());
         self.pos += 4;
         Ok(v)
     }
 
     pub fn read_u64(&mut self) -> io::Result<u64> {
         self.need(8)?;
-        let v = u64::from_le_bytes(self.data[self.pos..self.pos+8].try_into().unwrap());
+        let v = u64::from_le_bytes(self.data[self.pos..self.pos + 8].try_into().unwrap());
         self.pos += 8;
         Ok(v)
     }
@@ -94,14 +125,14 @@ impl<'a> SavestateReader<'a> {
 
     pub fn read_f32(&mut self) -> io::Result<f32> {
         self.need(4)?;
-        let v = f32::from_le_bytes(self.data[self.pos..self.pos+4].try_into().unwrap());
+        let v = f32::from_le_bytes(self.data[self.pos..self.pos + 4].try_into().unwrap());
         self.pos += 4;
         Ok(v)
     }
 
     pub fn read_f64(&mut self) -> io::Result<f64> {
         self.need(8)?;
-        let v = f64::from_le_bytes(self.data[self.pos..self.pos+8].try_into().unwrap());
+        let v = f64::from_le_bytes(self.data[self.pos..self.pos + 8].try_into().unwrap());
         self.pos += 8;
         Ok(v)
     }
@@ -114,7 +145,7 @@ impl<'a> SavestateReader<'a> {
     pub fn read_bytes(&mut self) -> io::Result<Vec<u8>> {
         let len = self.read_u32()? as usize;
         self.need(len)?;
-        let v = self.data[self.pos..self.pos+len].to_vec();
+        let v = self.data[self.pos..self.pos + len].to_vec();
         self.pos += len;
         Ok(v)
     }
@@ -122,11 +153,13 @@ impl<'a> SavestateReader<'a> {
     pub fn read_bytes_into(&mut self, dest: &mut [u8]) -> io::Result<()> {
         let len = self.read_u32()? as usize;
         if len != dest.len() {
-            return Err(io::Error::new(io::ErrorKind::InvalidData,
-                format!("expected {} bytes, got {}", dest.len(), len)));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected {} bytes, got {}", dest.len(), len),
+            ));
         }
         self.need(len)?;
-        dest.copy_from_slice(&self.data[self.pos..self.pos+len]);
+        dest.copy_from_slice(&self.data[self.pos..self.pos + len]);
         self.pos += len;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,6 +292,7 @@ mod tests {
             "input/bin/6502_functional_test.bin",
         )));
         emu.toggle_should_trigger_nmi(false);
+        emu.apu.write(0x4017, 0x40, 0);
         emu.toggle_debug_on_infinite_loop(false);
         emu.toggle_quiet_mode(true);
         emu.toggle_verbose_mode(false);
@@ -760,216 +761,6 @@ mod tests {
     }*/
 
     #[test]
-    fn test_nes_apu_len_ctr() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/1-len_ctr.nes",
-        )));
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n1-len_ctr\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    #[test]
-    fn test_nes_apu_len_table() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/2-len_table.nes",
-        )));
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n2-len_table\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    #[test]
-    fn test_nes_apu_irq_flag() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/3-irq_flag.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n3-irq_flag\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    /// Blargg `4-jitter.nes` — ignored: $4017 write-to-frame-alignment still off vs hardware.
-    #[test]
-    #[ignore]
-    fn test_nes_apu_jitter() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/4-jitter.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n4-jitter\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    /// Blargg `5-len_timing.nes` — ignored: depends on correct frame half-step clocking.
-    #[test]
-    #[ignore]
-    fn test_nes_apu_len_timing() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/5-len_timing.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n5-len_timing\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    /// Blargg `6-irq_flag_timing.nes` — ignored: frame IRQ flag set/clear timing.
-    #[test]
-    #[ignore]
-    fn test_nes_apu_irq_flag_timing() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/6-irq_flag_timing.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n6-irq_flag_timing\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    /// Blargg `7-dmc_basics.nes` — ignored: DMC DMA/sample unit timing.
-    #[test]
-    #[ignore]
-    fn test_nes_apu_dmc_basics() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/7-dmc_basics.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n7-dmc_basics\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    /// Blargg `8-dmc_rates.nes` — ignored: DMC rate table / timer edges.
-    #[test]
-    #[ignore]
-    fn test_nes_apu_dmc_rates() {
-        let mut emu: emu::Emulator = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/apu/8-dmc_rates.nes",
-        )));
-
-        emu.cpu.status = 0x34;
-        emu.cpu.sp = 0xfd;
-        emu.toggle_should_trigger_nmi(true);
-
-        emu.toggle_debug_on_infinite_loop(false);
-        emu.toggle_quiet_mode(true);
-        emu.toggle_verbose_mode(false);
-
-        emu.run();
-
-        let expected = String::from("\n8-dmc_rates\n\nPassed\n");
-        let buf = get_status_str(&mut emu, 0x6004, expected.len());
-
-        println!("{}", buf);
-        println!("status: {:02X}", emu.mem.cpu_read(0x6000));
-
-        assert_eq!(0, emu.mem.cpu_read(0x6000));
-        assert_eq!(expected, buf);
-    }
-
-    #[test]
     fn test_savestate_roundtrip_simple() {
         let mut emu = emu::Emulator::_new();
         emu.toggle_should_exit_on_infinite_loop(false);
@@ -1019,9 +810,8 @@ mod tests {
 
     #[test]
     fn test_savestate_roundtrip_nestest() {
-        let mut emu = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/nestest.nes",
-        )));
+        let mut emu =
+            emu::Emulator::new_headless(loader::load_nes(&String::from("input/nes/nestest.nes")));
         emu.cpu.pc = 0xc000;
         emu.cpu.sp = 0xfd;
         emu.cycles = 7;
@@ -1074,9 +864,8 @@ mod tests {
         }
 
         // Create a second emulator, run from scratch for 10000 cycles
-        let mut emu2 = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/nestest.nes",
-        )));
+        let mut emu2 =
+            emu::Emulator::new_headless(loader::load_nes(&String::from("input/nes/nestest.nes")));
         emu2.cpu.pc = 0xc000;
         emu2.cpu.sp = 0xfd;
         emu2.cycles = 7;
@@ -1107,9 +896,8 @@ mod tests {
 
     #[test]
     fn test_savestate_mapper_mismatch() {
-        let mut emu1 = emu::Emulator::new_headless(loader::load_nes(&String::from(
-            "input/nes/nestest.nes",
-        )));
+        let mut emu1 =
+            emu::Emulator::new_headless(loader::load_nes(&String::from("input/nes/nestest.nes")));
         emu1.toggle_quiet_mode(true);
 
         let saved = emu1.save_state_to_bytes();


### PR DESCRIPTION
## Summary

- **Frame counter mode 1**: Fix step mapping (steps 3/4 were swapped) and sequence length (37281→37282 CPU cycles) — resolves 5-len_timing
- **DMC output unit**: Rewrite with proper shift register/silence flag architecture, fix output level clamping bounds, initialize timer to DMC_PERIODS[0] matching power-on state — resolves 7-dmc_basics  
- **APU IRQ delivery**: Wire frame counter and DMC IRQs to the CPU via `service_pending_irq()` — resolves 6-irq_flag_timing
- **Cleanup**: Savestate refactoring, remove duplicate test functions, apply rustfmt

All 8 blargg APU tests now pass (348 total, 0 ignored).

## Test plan
- [x] All 348 tests pass (`cargo test`)
- [x] Previously-ignored tests 4-8 now pass: jitter, len_timing, irq_flag_timing, dmc_basics, dmc_rates
- [x] Previously-passing tests 1-3 still pass: len_ctr, len_table, irq_flag
- [x] No regressions (Klaus 6502, nestest, MMC3, PPU tests all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)