### PR TITLE
Add PAL region support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The project is a Cargo workspace with four crates:
 - **`libretro/`** (`krankulator-libretro`) — RetroArch/libretro core. Raw C FFI, no extra dependencies. Produces `krankulator_libretro.so/.dll/.dylib`.
 
 Key traits defined in core that frontends implement:
-- `IOHandler` (`core/src/emu/io/mod.rs`) — `init()`, `log()`, `poll()`, `render()`, `exit()`, `frame_time_ms()`
+- `IOHandler` (`core/src/emu/io/mod.rs`) — `init()`, `log()`, `poll()`, `render()`, `exit()`, `frame_time_ms()`, `set_frame_duration_nanos()`, `set_overscan_available()`
 - `AudioBackend` (`core/src/emu/audio/mod.rs`) — `push_samples()`, `flush()`, `clear()`
 
 ## Common Commands
@@ -108,9 +108,18 @@ cargo clippy --workspace
 - Main emulator struct that orchestrates CPU, PPU, APU, and memory
 - Handles cycle-accurate timing between components
 - `run()` — blocking loop for desktop; `run_one_frame()` — single-frame step for web/rAF
-- `new_with(io, mapper, audio)` — constructor taking trait objects for any frontend
+- `new_with(io, mapper, audio)` — constructor taking trait objects for any frontend (defaults to NTSC)
+- `new_with_region(io, mapper, audio, region)` — constructor with explicit region (NTSC or PAL)
 - `load_rom(mapper, path)` — hot-swap mapper for loading a new ROM mid-emulation (resets CPU/PPU/APU)
+- `load_rom_with_region(mapper, path, region)` — hot-swap with region change
 - `take_pending_open_rom()` — returns path from menu Open ROM action; desktop main loop re-enters `run()` after loading
+
+**Region (`emu/region.rs`)**
+- `Region` enum (Ntsc, Pal) with `config()` returning `RegionConfig`
+- `RegionConfig` struct: master clock dividers (CPU÷12/16, PPU÷4/5), scanline counts (262/312), CPU clock rate, frame duration, odd-frame skip flag, input poll interval
+- Master clock sub-dot accumulator: `master_clock_sub` tracks fractional PPU dots for PAL's non-integer 3.2:1 ratio. Pattern: 3,3,3,3,4 dots over 5 CPU cycles
+- Region auto-detected from iNES header (byte 9 for iNES 1.0, byte 12 for NES 2.0) with filename fallback (`(E)`, `(Europe)`, `(PAL)`)
+- Desktop `--region auto|ntsc|pal` CLI override (default: auto)
 
 **CPU (`emu/cpu/mod.rs`)**
 - MOS 6502 CPU implementation with all official opcodes
@@ -134,14 +143,15 @@ cargo clippy --workspace
 
 **APU (`emu/apu/`)**
 - Audio Processing Unit with pulse, triangle, noise, and DMC channels
-- Frame counter for audio timing
+- Frame counter for audio timing with region-specific cycle tables (NTSC/PAL)
+- DMC and noise period tables selected by region
 - Per-cycle mixer accumulation for proper anti-aliasing
 
 **Graphics (`emu/gfx/`)**
 - Frame buffer (`buf.rs`): 256x240 RGB pixels
 - Palette lookup table (`palette.rs`)
 - Bitmap font (`font.rs`): 8x8 pixel font with 1px outlined rendering for overlay text
-- Overlay (`overlay.rs`): frame time display (Tab to toggle), toast notifications for save/load/slot changes, persistent banner for no-ROM state, rewind status indicator
+- Overlay (`overlay.rs`): frame time display with region-aware budget percentage (Tab to toggle), toast notifications for save/load/slot changes, persistent banner for no-ROM state, rewind status indicator
 - CRT shaders (`shaders/`): CRT-Lottes-Fast (Timothy Lottes, public domain) in WGSL (`crt_lottes.wgsl`) and GLSL ES 3.0 (`crt_lottes_web.vert`/`.frag`). 8-tap gaussian filter, windowed cosine scanlines, aperture grille mask, barrel distortion, auto-exposure tonemapper. Toggled via F9 key or menu. GLSL version also used on Linux GTK backend (adapted to GL 3.30 at runtime).
 
 **Audio (`emu/audio/`)**
@@ -164,11 +174,13 @@ cargo clippy --workspace
 - `load_nes_from_bytes(&[u8])` — parse iNES ROM from byte slice
 - `load_nes_from_bytes_with_sram(&[u8], Option<Vec<u8>>)` — same but with pre-loaded SRAM (used by web)
 - `rom_has_battery(&[u8])` — check iNES header for battery flag
+- `detect_region(&[u8])` — detect region from iNES header only
+- `detect_region_with_filename(&[u8], Option<&str>)` — detect region from header + filename heuristic (`(E)`, `(Europe)`, `(PAL)`)
 - `InesLoader::load(path)` — load from filesystem (used by desktop)
 
 ### Desktop Frontend (`desktop/src/`)
 
-- `main.rs` — CLI (clap), wires IOHandler + AudioBackend to core; no-ROM launch shows banner screen; outer loop handles Open ROM by reloading mapper and re-entering `run()`; unsupported mapper errors toast on-screen
+- `main.rs` — CLI (clap), wires IOHandler + AudioBackend to core; `--region auto|ntsc|pal` flag; region auto-detection from header + filename; no-ROM launch shows banner screen; outer loop handles Open ROM by reloading mapper and re-entering `run()`; unsupported mapper errors toast on-screen
 - `settings.rs` — Persistent settings (`~/.config/krankulator/settings.txt`): `integer_scaling`, `scanlines`. Simple key=value format, no serde.
 - `io/mod.rs` — Shared menu construction (`build_menu_contents()`), `MenuIds`/`MenuItems` structs, recent ROMs persistence (`~/.config/krankulator/recent_roms.txt`, last 10), platform re-export (`PlatformIOHandler`)
 - `io/winit_backend.rs` — macOS/Windows: `WinitPixelsIOHandler` using winit 0.30 + pixels (wgpu), muda menu via `init_for_nsapp()`/`init_for_hwnd()`, CRT shader via `pixels.render_with()` + wgpu render pipeline, debug shell (shrust)
@@ -206,8 +218,10 @@ Two macros in `core/src/lib.rs`:
 ### Key Design Patterns
 
 **CPU-PPU Synchronization**
-- PPU runs at 3x CPU speed (3 PPU cycles per CPU cycle)
-- Interleaved per-cycle (CPU instruction, then 3 PPU dots, repeat)
+- NTSC: PPU runs at 3x CPU speed (master÷12=CPU, ÷4=PPU, clean 3:1 ratio)
+- PAL: PPU runs at 3.2x CPU speed (master÷16=CPU, ÷5=PPU, 16 PPU dots per 5 CPU cycles)
+- `master_clock` tracks PPU dots; `master_clock_sub` accumulates fractional dots for PAL (always 0 for NTSC)
+- Per-CPU-cycle: add `master_clocks_per_cpu` to sub, divide by `master_clocks_per_ppu` for PPU advance (3 or 3/3/3/3/4 pattern)
 
 **Memory Mapping**
 - Uses trait objects for different mapper implementations
@@ -221,7 +235,7 @@ Two macros in `core/src/lib.rs`:
 
 **Frame pacing (web)**
 - `requestAnimationFrame` loop with `performance.now()` time accumulator
-- Targets 60.0988 FPS (NTSC), caps at 2 frames per rAF to prevent spiral-of-death
+- Targets 60.0988 FPS (NTSC) or 50.007 FPS (PAL), caps at 2 frames per rAF to prevent spiral-of-death
 
 **Persistence (web)**
 - Save states and SRAM stored in `localStorage` as base64-encoded binary
@@ -242,7 +256,7 @@ Two macros in `core/src/lib.rs`:
 Cargo.toml          — Virtual workspace manifest
 core/               — Platform-independent emulation library
   src/lib.rs        — Crate root, exports test_input! and test_rom! macros
-  src/emu/          — Emulator core (cpu, ppu, apu, memory, io, gfx, audio, rewind)
+  src/emu/          — Emulator core (cpu, ppu, apu, memory, io, gfx, audio, rewind, region)
   src/emu/gfx/shaders/ — CRT-Lottes-Fast shader sources (crt_lottes.wgsl, crt_lottes_web.vert/.frag)
   src/util/         — Hex parsing, file I/O utilities
 desktop/            — Native frontend binary
@@ -278,7 +292,7 @@ docs/               — Design documents and dev setup guides
 
 ## Testing Strategy
 
-All emulation tests live in `core/` (523 tests, 31 ignored). Desktop has 6 tests including audio backend wiring.
+All emulation tests live in `core/` (551 tests, 21 ignored). Desktop has 6 tests including audio backend wiring.
 
 **Unit Tests**
 - Test individual CPU instructions and flag behavior
@@ -310,7 +324,9 @@ All emulation tests live in `core/` (523 tests, 31 ignored). Desktop has 6 tests
 - VBlank timing with level-based NMI output signal and CPU edge detection
 - VBL flag suppression when $2002 read races with VBL set (dot 0 prevents flag, same-dot cancels NMI edge)
 - Scroll register updates at correct cycle points during rendering
-- Per-dot cycle-accurate rendering
+- Per-dot cycle-accurate rendering, scanline count from region (262 NTSC, 312 PAL)
+- Odd-frame skip (NTSC only, disabled for PAL)
+- Overscan masking skipped for PAL (PAL TVs show full 240 lines)
 - Sprite 0 hit is approximate (position-based, not pixel-overlap)
 
 **Memory Mappers**
@@ -333,4 +349,4 @@ All emulation tests live in `core/` (523 tests, 31 ignored). Desktop has 6 tests
 - Indexed addressing performs dummy reads at uncorrected (pre-page-fix) address
 - RMW instructions always perform the dummy read regardless of page crossing
 
-The emulator passes standard NES test ROM suites including Klaus2m5, nestest, blargg CPU (v3+v5), blargg APU/APU 2005/APU reset, blargg PPU 2005, DMC status, cpu_exec_space (APU), CPU timing, branch timing, instruction timing, instruction misc (including dummy_reads_apu), CPU interrupt CLI latency, PPU VBL basics/set-time/clear/NMI control/suppression/nmi-off-timing/even-odd frames, OAM read/stress, PPU open bus, sprite hit, sprite overflow, and MMC3 (both variants). Ignored tests track known gaps: NMI hijacking (nmi_and_brk etc.), nmi_on_timing (1-dot PPU-CPU alignment), DMA cycle stealing, cpu_dummy_writes, and ppu_read_buffer.
+The emulator passes standard NES test ROM suites including Klaus2m5, nestest, blargg CPU (v3+v5), blargg APU/APU 2005/APU reset, blargg PAL APU (all 10), blargg PPU 2005, DMC status, cpu_exec_space (APU), CPU timing, branch timing, instruction timing, instruction misc (including dummy_reads_apu), CPU interrupt CLI latency, PPU VBL basics/set-time/clear/NMI control/suppression/nmi-off-timing/even-odd frames, OAM read/stress, PPU open bus, sprite hit, sprite overflow, and MMC3 (both variants). Ignored tests track known gaps: NMI hijacking (nmi_and_brk etc.), nmi_on_timing (1-dot PPU-CPU alignment), DMA cycle stealing, cpu_dummy_writes, and ppu_read_buffer.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Started as a learning-Rust project — a bare 6502 emulator iterating against th
 ## Features
 
 - **MOS 6502 CPU** — all official opcodes plus common unofficial ones (LAX, SAX, DCP, ISB, SLO, SRE, RLA, RRA, ANC, ALR, ARR, SBX, SHA, SHX, SHY, TAS, LAS, XAA)
-- **PPU** — per-dot cycle-accurate rendering, sprite evaluation, sprite 0 hit, even/odd frame timing
+- **PPU** — per-dot cycle-accurate rendering, sprite evaluation, sprite 0 hit, even/odd frame timing, NTSC (262 scanlines) and PAL (312 scanlines)
 - **APU** — pulse, triangle, noise, and DMC channels with nonlinear NES mixing, per-cycle accumulation, and IIR high-pass/low-pass filtering at 44.1 kHz
 - **Mappers** — NROM (0), MMC1 (1), UxROM (2), CNROM (3), MMC3 (4), MMC5 (5), AxROM (7), MMC2 (9), BNROM (34), Sunsoft 4 (68), Sunsoft FME-7 (69), GxROM (66), NES-EVENT (105), TxSROM (118), TQROM (119) — 695/695 licensed NTSC US games (100%)
 - **Battery-backed SRAM** — persistent `.sav` files for MMC1/MMC3/MMC5 cartridges
@@ -25,6 +25,7 @@ Started as a learning-Rust project — a bare 6502 emulator iterating against th
 - **WebAssembly frontend** — runs in the browser with Canvas 2D rendering, AudioWorklet audio, and touch controls for mobile
 - **RetroArch / libretro core** — load as a core in RetroArch for shaders, netplay, achievements, and universal controller support (Linux x86_64/aarch64, Windows, macOS)
 - **On-screen overlay** — 8x8 bitmap font with outlined text for frame time display (Tab) and toast notifications (save/load/slot); double-tap on mobile
+- **NTSC and PAL region support** — auto-detected from iNES header and filename, with `--region` CLI override. Master clock sub-dot accumulator handles PAL's non-integer 3.2:1 PPU:CPU ratio
 - **Headless mode** for testing and CI
 
 ## Architecture
@@ -69,7 +70,7 @@ library), `desktop/` (native frontend), `web/` (WebAssembly frontend), and `libr
 (RetroArch core). The core compiles to both native and wasm32 targets with zero cfg gates.
 
 The emulator runs a tight cycle loop: each iteration executes one CPU cycle, then steps
-the PPU three dots (3:1 PPU-to-CPU ratio), then cycles the APU and mapper. Memory mappers
+the PPU three dots (3:1 in NTSC, 3.2:1 in PAL via a sub-dot accumulator), then cycles the APU and mapper. Memory mappers
 are trait objects — each cartridge type implements its own bank switching, mirroring, and
 IRQ logic (e.g. MMC3 scanline counter, MMC5 PPU-fetch-based detection, FME-7 CPU-cycle IRQ). MMC3
 variants TxSROM (118) and TQROM (119) reuse the MMC3 engine with per-bank mirroring and
@@ -122,6 +123,7 @@ OPTIONS:
     -b, --breakpoint     Add CPU breakpoint (e.g. 0xC000)
     -l, --loader         Loader type: nes (default), ascii, bin
     --codeaddr           Code start address for bin/ascii loaders
+    --region             Region: auto (default), ntsc, pal
 ```
 
 ### Controls
@@ -199,7 +201,7 @@ waveform, spectrum, and envelope comparisons.
 
 ### Test ROM suites
 
-512 tests passing, 31 ignored (pending accuracy work). Test ROMs sourced from the [nes-test-roms](https://github.com/christopherpow/nes-test-roms) submodule.
+551 tests passing, 21 ignored (pending accuracy work). Test ROMs sourced from the [nes-test-roms](https://github.com/christopherpow/nes-test-roms) submodule.
 
 | Suite | Tests | Status |
 |-------|-------|--------|
@@ -215,6 +217,7 @@ waveform, spectrum, and envelope comparisons.
 | Blargg APU 2005 | All 11 tests | ✅ |
 | APU mixer references | Square, triangle, noise, and DMC output compared against hardware recordings | ✅ |
 | APU reset | $4015 cleared, $4017 timing/written, IRQ flag cleared, len ctrs enabled, works immediately | ✅ |
+| PAL APU | All 10 tests (len_ctr, len_table, irq_flag, clock_jitter, len_timing, irq_timing, len_halt/reload) | ✅ |
 | DMC tests | status, status_irq, buffer_retained, latency | ✅ |
 | cpu_exec_space | APU register space execution | ✅ |
 | cpu_exec_space | PPU I/O space execution | ❌ |

--- a/TODO.md
+++ b/TODO.md
@@ -96,7 +96,7 @@ Web: keyboard + touch controls (virtual d-pad with deadzone, A/B/Start/Select bu
   - Toast notifications for save/load state, slot cycling, errors
   - Auto-expire after 120 frames (~2 seconds), capped at 4 simultaneous
 - [x] Optional FPS counter overlay [S]
-  - Shows emulation time in ms and percentage of 16.64ms NTSC frame budget
+  - Shows emulation time in ms and percentage of frame budget (region-aware: 16.64ms NTSC, 20.00ms PAL)
 - [ ] Channel mute status indicator (when toggling audio channels 1-5) [XS]
 
 ---
@@ -132,7 +132,7 @@ Web: keyboard + touch controls (virtual d-pad with deadzone, A/B/Start/Select bu
 - [ ] Video recording (save to GIF or MP4) [L]
 - [ ] Game Genie code support [M]
 - [ ] NSF player mode (play NES Sound Format music files) [L]
-- [ ] PAL timing mode (50 Hz, different PPU/CPU ratios) [M]
+- [x] PAL timing mode (50 Hz, 3.2:1 PPU/CPU ratio via master clock sub-dot accumulator, region auto-detect from iNES header + filename heuristic, `--region` CLI override, all 10 blargg PAL APU tests passing) [M]
 
 ---
 
@@ -220,7 +220,7 @@ Test ROMs sourced from `test-roms/` git submodule ([christopherpow/nes-test-roms
 | apu_test | all 8 singles | ✅ | apu/mod.rs |
 | blargg_apu_2005 | all 11 | ✅ | apu/mod.rs |
 | apu_reset | all 6 | ✅ | apu/mod.rs |
-| pal_apu_tests | all 10 | ⏸ ignored (needs PAL) | apu/mod.rs |
+| pal_apu_tests | all 10 | ✅ | apu/mod.rs |
 | dmc_tests | status, status_irq, buffer_retained, latency | ✅ | integration_tests.rs |
 | oam_read | 1 | ✅ | integration_tests.rs |
 | ppu_vbl_nmi | 01, 03, 04, 05, 09, 10 | ✅ | integration_tests.rs |
@@ -300,7 +300,7 @@ Visual demos, interactive tests, or unsupported hardware — cannot use $6000 pr
 | m22chrbankingtest | Needs mapper 22 (VRC2a) |
 | MMC1_A12 | Visual/manual MMC1 test |
 | fdsirqtests | Needs FDS mapper |
-| pal_apu_tests | Wired up but ignored (needs PAL mode) |
+
 
 ---
 

--- a/core/src/emu/apu/channels/dmc.rs
+++ b/core/src/emu/apu/channels/dmc.rs
@@ -44,18 +44,36 @@ pub struct DmcChannel {
     // IRQ
     irq_enabled: bool,
     irq_pending: bool,
+
+    dmc_periods: [u16; 16],
 }
+
+const NTSC_DMC_PERIODS: [u16; 16] = [
+    428, 380, 340, 320, 286, 254, 226, 214, 190, 160, 142, 128, 106, 84, 72, 54,
+];
+const PAL_DMC_PERIODS: [u16; 16] = [
+    398, 354, 316, 298, 276, 236, 210, 198, 176, 148, 132, 118, 98, 78, 66, 50,
+];
 
 impl DmcChannel {
     pub fn new() -> Self {
+        Self::new_with_region(&crate::emu::region::Region::Ntsc.config())
+    }
+
+    pub fn new_with_region(region: &crate::emu::region::RegionConfig) -> Self {
+        use crate::emu::region::Region;
+        let periods = match region.region {
+            Region::Ntsc => NTSC_DMC_PERIODS,
+            Region::Pal => PAL_DMC_PERIODS,
+        };
         Self {
             control: 0,
             direct_load: 0,
             sample_address: 0,
             sample_length: 0,
 
-            timer: DMC_PERIODS[0],
-            timer_value: DMC_PERIODS[0],
+            timer: periods[0],
+            timer_value: periods[0],
 
             enabled: false,
 
@@ -74,6 +92,7 @@ impl DmcChannel {
 
             irq_enabled: false,
             irq_pending: false,
+            dmc_periods: periods,
         }
     }
 
@@ -82,8 +101,8 @@ impl DmcChannel {
         self.direct_load = 0;
         self.sample_address = 0;
         self.sample_length = 0;
-        self.timer = DMC_PERIODS[0];
-        self.timer_value = DMC_PERIODS[0];
+        self.timer = self.dmc_periods[0];
+        self.timer_value = self.dmc_periods[0];
         self.enabled = false;
         self.sample_buffer = 0;
         self.sample_buffer_empty = true;
@@ -145,7 +164,7 @@ impl DmcChannel {
         self.control = value;
         let irq_enable = (value >> 7) & 1 != 0;
         self.irq_enabled = irq_enable;
-        self.timer = DMC_PERIODS[(value & PERIOD_INDEX_MASK) as usize];
+        self.timer = self.dmc_periods[(value & PERIOD_INDEX_MASK) as usize];
         if !irq_enable {
             self.irq_pending = false;
         }
@@ -277,11 +296,6 @@ impl DmcChannel {
     }
 }
 
-// DMC period lookup table
-const DMC_PERIODS: [u16; 16] = [
-    428, 380, 340, 320, 286, 254, 226, 214, 190, 160, 142, 128, 106, 84, 72, 54,
-];
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,8 +356,8 @@ mod tests {
         assert_eq!(dmc.direct_load, 0);
         assert_eq!(dmc.sample_address, 0);
         assert_eq!(dmc.sample_length, 0);
-        assert_eq!(dmc.timer, DMC_PERIODS[0]);
-        assert_eq!(dmc.timer_value, DMC_PERIODS[0]);
+        assert_eq!(dmc.timer, NTSC_DMC_PERIODS[0]);
+        assert_eq!(dmc.timer_value, NTSC_DMC_PERIODS[0]);
         assert!(!dmc.enabled);
         assert_eq!(dmc.sample_buffer, 0);
         assert!(dmc.sample_buffer_empty);
@@ -366,9 +380,9 @@ mod tests {
 
         // Test period setting
         dmc.set_control(0b00001111); // Period 15
-        assert_eq!(dmc.timer, DMC_PERIODS[15]);
+        assert_eq!(dmc.timer, NTSC_DMC_PERIODS[15]);
         // timer_value is NOT reset by set_control (hardware behavior)
-        assert_eq!(dmc.timer_value, DMC_PERIODS[0]);
+        assert_eq!(dmc.timer_value, NTSC_DMC_PERIODS[0]);
     }
 
     #[test]
@@ -440,7 +454,7 @@ mod tests {
         let mut dmc = DmcChannel::new();
         let mut mem = DummyMemory;
 
-        dmc.set_control(0x01); // Period = DMC_PERIODS[1] = 380
+        dmc.set_control(0x01); // Period = NTSC_DMC_PERIODS[1] = 380
         dmc.enabled = true;
         dmc.bytes_remaining = 10;
         dmc.timer_value = 0; // Force timer to expire on next cycle
@@ -582,13 +596,13 @@ mod tests {
     #[test]
     fn test_dmc_periods_table() {
         // Test some known values from the table
-        assert_eq!(DMC_PERIODS[0], 428);
-        assert_eq!(DMC_PERIODS[1], 380);
-        assert_eq!(DMC_PERIODS[15], 54);
+        assert_eq!(NTSC_DMC_PERIODS[0], 428);
+        assert_eq!(NTSC_DMC_PERIODS[1], 380);
+        assert_eq!(NTSC_DMC_PERIODS[15], 54);
 
         // Test that periods decrease with index (higher frequency)
         for i in 1..16 {
-            assert!(DMC_PERIODS[i] < DMC_PERIODS[i - 1]);
+            assert!(NTSC_DMC_PERIODS[i] < NTSC_DMC_PERIODS[i - 1]);
         }
     }
 

--- a/core/src/emu/apu/channels/noise.rs
+++ b/core/src/emu/apu/channels/noise.rs
@@ -33,10 +33,28 @@ pub struct NoiseChannel {
 
     // Output
     output: f32,
+
+    noise_periods: [u16; 16],
 }
+
+const NTSC_NOISE_PERIODS: [u16; 16] = [
+    4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 4068,
+];
+const PAL_NOISE_PERIODS: [u16; 16] = [
+    4, 8, 14, 30, 60, 88, 118, 148, 188, 236, 354, 472, 708, 944, 1890, 3778,
+];
 
 impl NoiseChannel {
     pub fn new() -> Self {
+        Self::new_with_region(&crate::emu::region::Region::Ntsc.config())
+    }
+
+    pub fn new_with_region(region: &crate::emu::region::RegionConfig) -> Self {
+        use crate::emu::region::Region;
+        let periods = match region.region {
+            Region::Ntsc => NTSC_NOISE_PERIODS,
+            Region::Pal => PAL_NOISE_PERIODS,
+        };
         Self {
             control: 0,
             volume: 0,
@@ -47,8 +65,8 @@ impl NoiseChannel {
             envelope_decay_level: 0,
 
             period: 0,
-            timer: NOISE_PERIODS[0],       // Start with a valid timer value
-            timer_value: NOISE_PERIODS[0], // Start with a valid timer value
+            timer: periods[0],
+            timer_value: periods[0],
 
             length_counter: 0,
             length_counter_halt: false,
@@ -57,6 +75,7 @@ impl NoiseChannel {
 
             shift_register: LFSR_INITIAL,
             output: 0.0,
+            noise_periods: periods,
         }
     }
 
@@ -68,8 +87,8 @@ impl NoiseChannel {
         self.envelope_divider = 0;
         self.envelope_decay_level = 0;
         self.period = 0;
-        self.timer = NOISE_PERIODS[0];
-        self.timer_value = NOISE_PERIODS[0];
+        self.timer = self.noise_periods[0];
+        self.timer_value = self.noise_periods[0];
         self.length_counter = 0;
         self.length_counter_halt = false;
         self.enabled = false;
@@ -121,7 +140,7 @@ impl NoiseChannel {
 
     pub fn set_period(&mut self, value: u8) {
         self.period = value & PERIOD_INDEX_MASK;
-        self.timer = NOISE_PERIODS[self.period as usize];
+        self.timer = self.noise_periods[self.period as usize];
         self.timer_value = self.timer;
         self.control = (self.control & !MODE_BIT) | (value & MODE_BIT);
     }
@@ -220,11 +239,6 @@ impl NoiseChannel {
     }
 }
 
-// Noise period lookup table
-const NOISE_PERIODS: [u16; 16] = [
-    4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 4068,
-];
-
 // Length counter lookup table
 const LENGTH_COUNTER_TABLE: [u8; 32] = [
     10, 254, 20, 2, 40, 4, 80, 6, 160, 8, 60, 10, 14, 12, 26, 14, 12, 16, 24, 18, 48, 20, 96, 22,
@@ -245,8 +259,8 @@ mod tests {
         assert_eq!(noise.envelope_divider, 0);
         assert_eq!(noise.envelope_decay_level, 0);
         assert_eq!(noise.period, 0);
-        assert_eq!(noise.timer, NOISE_PERIODS[0]);
-        assert_eq!(noise.timer_value, NOISE_PERIODS[0]);
+        assert_eq!(noise.timer, NTSC_NOISE_PERIODS[0]);
+        assert_eq!(noise.timer_value, NTSC_NOISE_PERIODS[0]);
         assert_eq!(noise.length_counter, 0);
         assert!(!noise.length_counter_halt);
         assert!(!noise.enabled);
@@ -281,12 +295,12 @@ mod tests {
         // Test period 0
         noise.set_period(0x00);
         assert_eq!(noise.period, 0);
-        assert_eq!(noise.timer, NOISE_PERIODS[0]);
+        assert_eq!(noise.timer, NTSC_NOISE_PERIODS[0]);
 
         // Test period 15
         noise.set_period(0x0F);
         assert_eq!(noise.period, 15);
-        assert_eq!(noise.timer, NOISE_PERIODS[15]);
+        assert_eq!(noise.timer, NTSC_NOISE_PERIODS[15]);
 
         // Test that higher bits are ignored
         noise.set_period(0xF0);
@@ -464,13 +478,13 @@ mod tests {
     #[test]
     fn test_noise_periods_table() {
         // Test some known values from the table
-        assert_eq!(NOISE_PERIODS[0], 4);
-        assert_eq!(NOISE_PERIODS[1], 8);
-        assert_eq!(NOISE_PERIODS[15], 4068);
+        assert_eq!(NTSC_NOISE_PERIODS[0], 4);
+        assert_eq!(NTSC_NOISE_PERIODS[1], 8);
+        assert_eq!(NTSC_NOISE_PERIODS[15], 4068);
 
         // Test that periods increase with index
         for i in 1..16 {
-            assert!(NOISE_PERIODS[i] > NOISE_PERIODS[i - 1]);
+            assert!(NTSC_NOISE_PERIODS[i] > NTSC_NOISE_PERIODS[i - 1]);
         }
     }
 

--- a/core/src/emu/apu/frame_counter.rs
+++ b/core/src/emu/apu/frame_counter.rs
@@ -18,21 +18,36 @@ pub struct FrameCounter {
     reset_delay: u8,
     pending_write: u8,
     block_tick: u8,
+    mode0_cycles: [u32; 6],
+    mode1_cycles: [u32; 6],
 }
 
-const MODE0_CYCLES: [u32; 6] = [7457, 14913, 22371, 29828, 29829, 29830];
-const MODE1_CYCLES: [u32; 6] = [7457, 14913, 22371, 29829, 37281, 37282];
+const NTSC_MODE0_CYCLES: [u32; 6] = [7457, 14913, 22371, 29828, 29829, 29830];
+const NTSC_MODE1_CYCLES: [u32; 6] = [7457, 14913, 22371, 29829, 37281, 37282];
+const PAL_MODE0_CYCLES: [u32; 6] = [8313, 16627, 24939, 33252, 33253, 33254];
+const PAL_MODE1_CYCLES: [u32; 6] = [8313, 16627, 24939, 33253, 41565, 41566];
 
 impl FrameCounter {
     pub fn new() -> Self {
+        Self::new_with_region(&crate::emu::region::Region::Ntsc.config())
+    }
+
+    pub fn new_with_region(region: &crate::emu::region::RegionConfig) -> Self {
+        use crate::emu::region::Region;
+        let (mode0, mode1) = match region.region {
+            Region::Ntsc => (NTSC_MODE0_CYCLES, NTSC_MODE1_CYCLES),
+            Region::Pal => (PAL_MODE0_CYCLES, PAL_MODE1_CYCLES),
+        };
         Self {
             mode: 0,
             step: 0,
-            cycles: 10, // hardware powers on as if $4017=$00 written ~10 clocks before first instruction
+            cycles: 10,
             irq_inhibit: false,
             reset_delay: 0,
             pending_write: 0,
             block_tick: 0,
+            mode0_cycles: mode0,
+            mode1_cycles: mode1,
         }
     }
 
@@ -87,7 +102,7 @@ impl FrameCounter {
         if self.step >= 6 {
             return FrameStep::None;
         }
-        let target = MODE0_CYCLES[self.step as usize];
+        let target = self.mode0_cycles[self.step as usize];
         if self.cycles < target {
             return FrameStep::None;
         }
@@ -111,7 +126,7 @@ impl FrameCounter {
         if self.step >= 6 {
             return FrameStep::None;
         }
-        let target = MODE1_CYCLES[self.step as usize];
+        let target = self.mode1_cycles[self.step as usize];
         if self.cycles < target {
             return FrameStep::None;
         }

--- a/core/src/emu/apu/mod.rs
+++ b/core/src/emu/apu/mod.rs
@@ -2,8 +2,7 @@ pub mod channels;
 pub mod frame_counter;
 
 pub const SAMPLE_RATE: u32 = 44100;
-pub const CPU_CLOCK_RATE: f64 = 1_789_773.0;
-pub const CYCLES_PER_SAMPLE: f64 = CPU_CLOCK_RATE / SAMPLE_RATE as f64;
+pub const CPU_CLOCK_RATE_NTSC: f64 = 1_789_773.0;
 
 // --- APU register addresses ---
 
@@ -155,6 +154,8 @@ pub struct APU {
     last_4017_write: Option<u8>,
 
     audio_filter: AudioFilter,
+    cycles_per_sample: f64,
+    region: crate::emu::region::Region,
     // Pulse and noise timers tick every 2 CPU cycles (half-rate)
     half_clock: bool,
     expansion_audio: f32,
@@ -162,13 +163,18 @@ pub struct APU {
 
 impl APU {
     pub fn new() -> Self {
+        Self::new_with_region(&crate::emu::region::Region::Ntsc.config())
+    }
+
+    pub fn new_with_region(region: &crate::emu::region::RegionConfig) -> Self {
+        let cycles_per_sample = region.cpu_clock_rate / SAMPLE_RATE as f64;
         let mut apu = Self {
             pulse1: PulseChannel::new(0),
             pulse2: PulseChannel::new(1),
             triangle: TriangleChannel::new(),
-            noise: NoiseChannel::new(),
-            dmc: DmcChannel::new(),
-            frame_counter: FrameCounter::new(),
+            noise: NoiseChannel::new_with_region(region),
+            dmc: DmcChannel::new_with_region(region),
+            frame_counter: FrameCounter::new_with_region(region),
 
             sample_buffer: vec![0.0; SAMPLE_BUFFER_SIZE],
             sample_index: 0,
@@ -182,6 +188,8 @@ impl APU {
             mute_mask: 0,
             last_4017_write: None,
             audio_filter: AudioFilter::new(SAMPLE_RATE),
+            cycles_per_sample,
+            region: region.region,
             half_clock: false,
             expansion_audio: 0.0,
         };
@@ -195,7 +203,7 @@ impl APU {
         self.triangle.hard_reset();
         self.noise.hard_reset();
         self.dmc.hard_reset();
-        self.frame_counter = FrameCounter::new();
+        self.frame_counter = FrameCounter::new_with_region(&self.region.config());
         self.last_4017_write = None;
         self.reset_common();
     }
@@ -207,10 +215,10 @@ impl APU {
         self.noise.set_enabled(false);
         self.dmc.set_enabled(false);
         if let Some(val) = self.last_4017_write {
-            self.frame_counter = FrameCounter::new();
+            self.frame_counter = FrameCounter::new_with_region(&self.region.config());
             self.frame_counter.reset_with_value(val);
         } else {
-            self.frame_counter = FrameCounter::new();
+            self.frame_counter = FrameCounter::new_with_region(&self.region.config());
         }
         self.reset_common();
     }
@@ -386,8 +394,8 @@ impl APU {
         self.sample_accumulator_count += 1;
 
         self.cycles_since_sample += 1.0;
-        if self.cycles_since_sample >= CYCLES_PER_SAMPLE {
-            self.cycles_since_sample -= CYCLES_PER_SAMPLE;
+        if self.cycles_since_sample >= self.cycles_per_sample {
+            self.cycles_since_sample -= self.cycles_per_sample;
             self.emit_sample();
         }
     }
@@ -837,7 +845,8 @@ mod tests {
         apu.write(0x4002, 0x10, 0); // Timer low
         apu.write(0x4003, 0x00, 0); // Timer high
 
-        for _ in 0..CYCLES_PER_SAMPLE as u32 + 1 {
+        let cycles_per_sample = CPU_CLOCK_RATE_NTSC / SAMPLE_RATE as f64;
+        for _ in 0..cycles_per_sample as u32 + 1 {
             apu.cycle(0, &mut DummyMemory);
         }
 
@@ -848,7 +857,8 @@ mod tests {
     fn test_apu_get_audio_samples() {
         let mut apu = APU::new();
 
-        for _ in 0..(CYCLES_PER_SAMPLE * 5.0) as u32 {
+        let cycles_per_sample = CPU_CLOCK_RATE_NTSC / SAMPLE_RATE as f64;
+        for _ in 0..(cycles_per_sample * 5.0) as u32 {
             apu.cycle(0, &mut DummyMemory);
         }
 
@@ -876,8 +886,9 @@ mod tests {
         // Test sample rate
         assert_eq!(SAMPLE_RATE, 44100);
 
-        assert!(CYCLES_PER_SAMPLE > 40.0);
-        assert!(CYCLES_PER_SAMPLE < 41.0);
+        let cycles_per_sample = CPU_CLOCK_RATE_NTSC / SAMPLE_RATE as f64;
+        assert!(cycles_per_sample > 40.0);
+        assert!(cycles_per_sample < 41.0);
     }
 
     #[test]
@@ -1192,7 +1203,11 @@ mod tests {
         use crate::emu::io::loader;
         use crate::util::get_status_str;
 
-        let mut emu = emu::Emulator::new_headless(loader::load_nes(&String::from(rom_path)));
+        let mapper = loader::load_nes(&String::from(rom_path));
+        let audio =
+            Box::new(emu::audio::SilentAudioOutput::new()) as Box<dyn emu::audio::AudioBackend>;
+        let iohandler = Box::new(emu::io::HeadlessIOHandler {});
+        let mut emu = emu::Emulator::new_with_region(iohandler, mapper, audio, emu::Region::Pal);
         emu.cpu.status = 0x34;
         emu.cpu.sp = 0xfd;
         emu.toggle_should_trigger_nmi(true);
@@ -1214,25 +1229,21 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_ctr() {
         run_pal_apu_rom(test_rom!("pal_apu_tests/01.len_ctr.nes"), "01.len_ctr");
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_table() {
         run_pal_apu_rom(test_rom!("pal_apu_tests/02.len_table.nes"), "02.len_table");
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_irq_flag() {
         run_pal_apu_rom(test_rom!("pal_apu_tests/03.irq_flag.nes"), "03.irq_flag");
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_clock_jitter() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/04.clock_jitter.nes"),
@@ -1241,7 +1252,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_timing_mode0() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/05.len_timing_mode0.nes"),
@@ -1250,7 +1260,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_timing_mode1() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/06.len_timing_mode1.nes"),
@@ -1259,7 +1268,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_irq_flag_timing() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/07.irq_flag_timing.nes"),
@@ -1268,7 +1276,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_irq_timing() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/08.irq_timing.nes"),
@@ -1277,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_halt_timing() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/10.len_halt_timing.nes"),
@@ -1286,7 +1292,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_pal_apu_len_reload_timing() {
         run_pal_apu_rom(
             test_rom!("pal_apu_tests/11.len_reload_timing.nes"),

--- a/core/src/emu/gfx/overlay.rs
+++ b/core/src/emu/gfx/overlay.rs
@@ -3,7 +3,6 @@ use super::font;
 
 const TOAST_DURATION: u32 = 120;
 const TOAST_LINE_SPACING: i32 = 10;
-const NTSC_FRAME_MS: f64 = 16.64;
 const FG: (u8, u8, u8) = (255, 255, 255);
 const OUTLINE: (u8, u8, u8) = (0, 0, 0);
 
@@ -15,6 +14,7 @@ struct Toast {
 pub struct Overlay {
     enabled: bool,
     frame_time_text: String,
+    frame_budget_ms: f64,
     toasts: Vec<Toast>,
     banner: Option<String>,
     rewind_status: Option<String>,
@@ -26,6 +26,7 @@ impl Overlay {
         Self {
             enabled: false,
             frame_time_text: String::new(),
+            frame_budget_ms: 16.64,
             toasts: Vec::new(),
             banner: None,
             rewind_status: None,
@@ -37,8 +38,12 @@ impl Overlay {
         self.enabled = !self.enabled;
     }
 
+    pub fn set_frame_budget_ms(&mut self, ms: f64) {
+        self.frame_budget_ms = ms;
+    }
+
     pub fn set_frame_time(&mut self, emu_ms: f64) {
-        let budget_pct = (emu_ms / NTSC_FRAME_MS) * 100.0;
+        let budget_pct = (emu_ms / self.frame_budget_ms) * 100.0;
         self.frame_time_text = format!("{:.1}ms ({:.0}%)", emu_ms, budget_pct);
     }
 

--- a/core/src/emu/io/loader.rs
+++ b/core/src/emu/io/loader.rs
@@ -148,6 +148,40 @@ pub fn rom_has_battery(bytes: &[u8]) -> bool {
     bytes.len() > 6 && (bytes[6] & FLAG_BATTERY) != 0
 }
 
+pub fn detect_region(bytes: &[u8]) -> crate::emu::region::Region {
+    detect_region_with_filename(bytes, None)
+}
+
+pub fn detect_region_with_filename(
+    bytes: &[u8],
+    filename: Option<&str>,
+) -> crate::emu::region::Region {
+    use crate::emu::region::Region;
+    if bytes.len() >= INES_HEADER_SIZE {
+        let is_nes2 = bytes[7] & NES2_DETECT_MASK == NES2_DETECT_VALUE;
+        if is_nes2 {
+            return match bytes[12] & 0x03 {
+                1 => Region::Pal,
+                _ => Region::Ntsc,
+            };
+        }
+        if bytes[9] & 0x01 != 0 {
+            return Region::Pal;
+        }
+    }
+    if let Some(name) = filename {
+        if filename_suggests_pal(name) {
+            return Region::Pal;
+        }
+    }
+    Region::Ntsc
+}
+
+fn filename_suggests_pal(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("(e)") || lower.contains("(europe)") || lower.contains("(pal)")
+}
+
 fn load_nes_from_bytes_inner(
     bytes: &[u8],
     sram_data: Option<Vec<u8>>,
@@ -427,5 +461,86 @@ mod tests {
         let bnrom_result = l.load(bnrom_path.to_str().unwrap());
         std::fs::remove_file(&bnrom_path).unwrap();
         assert_eq!(bnrom_result.unwrap().mapper_id(), 34);
+    }
+
+    #[test]
+    fn test_detect_region_ines1_ntsc() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[9] = 0x00;
+        assert_eq!(detect_region(&bytes), crate::emu::region::Region::Ntsc);
+    }
+
+    #[test]
+    fn test_detect_region_ines1_pal() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[9] = 0x01;
+        assert_eq!(detect_region(&bytes), crate::emu::region::Region::Pal);
+    }
+
+    #[test]
+    fn test_detect_region_nes2_ntsc() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[7] = NES2_DETECT_VALUE;
+        bytes[12] = 0x00;
+        assert_eq!(detect_region(&bytes), crate::emu::region::Region::Ntsc);
+    }
+
+    #[test]
+    fn test_detect_region_nes2_pal() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[7] = NES2_DETECT_VALUE;
+        bytes[12] = 0x01;
+        assert_eq!(detect_region(&bytes), crate::emu::region::Region::Pal);
+    }
+
+    #[test]
+    fn test_detect_region_short_header() {
+        assert_eq!(detect_region(&[0; 4]), crate::emu::region::Region::Ntsc);
+    }
+
+    #[test]
+    fn test_detect_region_filename_europe() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[9] = 0x00;
+        assert_eq!(
+            detect_region_with_filename(&bytes, Some("Super Mario Bros (E).nes")),
+            crate::emu::region::Region::Pal
+        );
+        assert_eq!(
+            detect_region_with_filename(&bytes, Some("Game (Europe).nes")),
+            crate::emu::region::Region::Pal
+        );
+        assert_eq!(
+            detect_region_with_filename(&bytes, Some("Game (PAL).nes")),
+            crate::emu::region::Region::Pal
+        );
+    }
+
+    #[test]
+    fn test_detect_region_filename_no_match() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[9] = 0x00;
+        assert_eq!(
+            detect_region_with_filename(&bytes, Some("Game (U).nes")),
+            crate::emu::region::Region::Ntsc
+        );
+    }
+
+    #[test]
+    fn test_detect_region_header_overrides_filename() {
+        let mut bytes = vec![0u8; INES_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(b"NES\x1A");
+        bytes[7] = NES2_DETECT_VALUE;
+        bytes[12] = 0x00;
+        assert_eq!(
+            detect_region_with_filename(&bytes, Some("Game (E).nes")),
+            crate::emu::region::Region::Ntsc
+        );
     }
 }

--- a/core/src/emu/io/mod.rs
+++ b/core/src/emu/io/mod.rs
@@ -43,6 +43,8 @@ pub trait IOHandler {
     fn frame_time_ms(&self) -> Option<f64> {
         None
     }
+    fn set_frame_duration_nanos(&mut self, _nanos: u64) {}
+    fn set_overscan_available(&mut self, _available: bool) {}
     fn on_debug(&mut self, ctx: &mut DebugContext) {
         *ctx.stepping = false;
     }

--- a/core/src/emu/mod.rs
+++ b/core/src/emu/mod.rs
@@ -110,16 +110,29 @@ pub struct Emulator {
 
 impl Emulator {
     pub fn new_headless(mapper: Box<dyn memory::MemoryMapper>) -> Emulator {
+        Self::new_headless_with_region(mapper, Region::Ntsc)
+    }
+
+    pub fn new_headless_with_region(
+        mapper: Box<dyn memory::MemoryMapper>,
+        region: Region,
+    ) -> Emulator {
         let audio = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
         let iohandler = Box::new(io::HeadlessIOHandler {});
-
-        Emulator::new_with(iohandler, mapper, audio)
+        Emulator::new_with_region(iohandler, mapper, audio, region)
     }
 
     pub fn new_capturing(mapper: Box<dyn memory::MemoryMapper>) -> Emulator {
+        Self::new_capturing_with_region(mapper, Region::Ntsc)
+    }
+
+    pub fn new_capturing_with_region(
+        mapper: Box<dyn memory::MemoryMapper>,
+        region: Region,
+    ) -> Emulator {
         let audio = Box::new(CapturingAudioOutput::new()) as Box<dyn AudioBackend>;
         let iohandler = Box::new(io::HeadlessIOHandler {});
-        Emulator::new_with(iohandler, mapper, audio)
+        Emulator::new_with_region(iohandler, mapper, audio, region)
     }
 
     pub fn drain_captured_audio(&mut self) -> Vec<f32> {
@@ -672,7 +685,7 @@ impl Emulator {
             }
             self.overlay.tick();
             self.overlay.draw(&mut self.buf);
-            if self.overscan {
+            if self.overscan && self.region.region != region::Region::Pal {
                 self.buf.mask_overscan();
             }
             self.iohandler.render(&self.buf);

--- a/core/src/emu/mod.rs
+++ b/core/src/emu/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 pub mod io;
 pub mod memory;
 pub mod ppu;
+pub mod region;
 pub mod rewind;
 pub mod savestate;
 
@@ -17,6 +18,7 @@ use cpu::opcodes;
 use std::collections::HashSet;
 
 use self::audio::{AudioBackend, CapturingAudioOutput, SilentAudioOutput};
+pub use self::region::{Region, RegionConfig};
 
 // CPU initialization values (per NES power-on state)
 const CPU_INIT_SP: u8 = 0xFD;
@@ -24,9 +26,6 @@ const CPU_INIT_STATUS: u8 = 0x34;
 
 // PPU register warmup period — writes to PPU registers are ignored for this many CPU cycles after power-on/reset
 const PPU_WARMUP_CPU_CYCLES: u64 = 29_658;
-
-// Input polling interval (~1000 Hz: 1,789,773 CPU Hz / 1790 ≈ 1ms)
-const INPUT_POLL_INTERVAL: u64 = 1790;
 
 // NES memory-mapped I/O addresses
 const APU_STATUS_ADDR: u16 = 0x4015;
@@ -78,10 +77,13 @@ pub struct Emulator {
     should_exit_on_infinite_loop: bool,
     verbose: bool,
 
+    pub region: RegionConfig,
     pub instructions: u64,
     pub cycles: u64,
     pub master_clock: u64,
+    master_clock_sub: u64,
     instruction_start_dot: u64,
+    instruction_start_sub: u64,
     cpu_bus_cycle_offset: u8,
     cpu_open_bus: u8,
     irq_sample_deadline: u64,
@@ -131,10 +133,23 @@ impl Emulator {
 
     pub fn new_with(
         iohandler: Box<dyn io::IOHandler>,
-        mut mapper: Box<dyn memory::MemoryMapper>,
+        mapper: Box<dyn memory::MemoryMapper>,
         audio: Box<dyn AudioBackend>,
     ) -> Emulator {
+        Self::new_with_region(iohandler, mapper, audio, Region::Ntsc)
+    }
+
+    pub fn new_with_region(
+        mut iohandler: Box<dyn io::IOHandler>,
+        mut mapper: Box<dyn memory::MemoryMapper>,
+        audio: Box<dyn AudioBackend>,
+        region: Region,
+    ) -> Emulator {
         let lookup: Box<opcodes::Lookup> = Box::new(opcodes::Lookup::new());
+        let region_config = region.config();
+        let frame_budget_ms = region_config.frame_duration_nanos as f64 / 1_000_000.0;
+        iohandler.set_frame_duration_nanos(region_config.frame_duration_nanos);
+        iohandler.set_overscan_available(region_config.region != Region::Pal);
 
         let mut cpu = cpu::Cpu::new();
         cpu.pc = mapper.code_start();
@@ -145,8 +160,8 @@ impl Emulator {
             cpu: cpu,
             lookup: lookup,
             mem: mapper,
-            ppu: ppu::PPU::new(),
-            apu: apu::APU::new(),
+            ppu: ppu::PPU::new_with_region(&region_config),
+            apu: apu::APU::new_with_region(&region_config),
             buf: Box::new(buf),
             iohandler: iohandler,
             stepping: false,
@@ -157,10 +172,13 @@ impl Emulator {
             should_debug_on_infinite_loop: false,
             should_exit_on_infinite_loop: true,
             verbose: true,
+            region: region_config,
             instructions: 0,
             cycles: 0,
             master_clock: 0,
+            master_clock_sub: 0,
             instruction_start_dot: 0,
+            instruction_start_sub: 0,
             cpu_bus_cycle_offset: 0,
             cpu_open_bus: 0,
             irq_sample_deadline: 0,
@@ -169,12 +187,15 @@ impl Emulator {
             should_trigger_nmi: false,
             nmi_countdown: -1,
             audio: audio,
-            // https://www.nesdev.org/wiki/PPU_power_up_state — model as ignoring host writes briefly after power on.
             ppu_register_warmup_until_cpu_cycle: PPU_WARMUP_CPU_CYCLES,
             rom_path: None,
             savestate_slot: 0,
             last_rendered_frame: 0,
-            overlay: gfx::overlay::Overlay::new(),
+            overlay: {
+                let mut o = gfx::overlay::Overlay::new();
+                o.set_frame_budget_ms(frame_budget_ms);
+                o
+            },
             pending_open_rom: None,
             rewind_buffer: rewind::RewindBuffer::new(),
             rewind_capture_tick: false,
@@ -225,6 +246,16 @@ impl Emulator {
     }
 
     pub fn load_rom(&mut self, mapper: Box<dyn memory::MemoryMapper>, path: &str) {
+        self.load_rom_with_region(mapper, path, self.region.region);
+    }
+
+    pub fn load_rom_with_region(
+        &mut self,
+        mapper: Box<dyn memory::MemoryMapper>,
+        path: &str,
+        region: Region,
+    ) {
+        let region_config = region.config();
         self.mem = mapper;
         self.rom_path = Some(path.to_string());
         self.cpu.pc = self.mem.code_start();
@@ -236,12 +267,13 @@ impl Emulator {
         self.cpu.cycle = 0;
         self.cycles = 0;
         self.master_clock = 0;
+        self.master_clock_sub = 0;
         self.instructions = 0;
-        self.ppu = ppu::PPU::new();
-        self.apu.reset();
+        self.ppu = ppu::PPU::new_with_region(&region_config);
+        self.apu = apu::APU::new_with_region(&region_config);
         self.audio.clear();
         self.nmi_countdown = -1;
-        self.ppu_register_warmup_until_cpu_cycle = 29_658;
+        self.ppu_register_warmup_until_cpu_cycle = PPU_WARMUP_CPU_CYCLES;
         self.savestate_slot = 0;
         self.last_rendered_frame = 0;
         self.overlay.set_banner(None);
@@ -251,6 +283,13 @@ impl Emulator {
         self.rewind_buffer.clear();
         self.rewind_capture_tick = false;
         self.rewinding = false;
+        self.region = region_config;
+        self.iohandler
+            .set_frame_duration_nanos(self.region.frame_duration_nanos);
+        self.iohandler
+            .set_overscan_available(self.region.region != Region::Pal);
+        self.overlay
+            .set_frame_budget_ms(self.region.frame_duration_nanos as f64 / 1_000_000.0);
     }
 
     pub fn toggle_verbose_mode(&mut self, verbose: bool) {
@@ -306,6 +345,9 @@ impl Emulator {
         w.write_i8(self.nmi_countdown);
         w.write_u64(self.ppu_register_warmup_until_cpu_cycle);
         w.write_u64(self.instructions);
+        w.write_u8(self.region.region.to_byte());
+        w.write_u64(self.master_clock_sub);
+        w.write_u64(self.instruction_start_sub);
         w.finish()
     }
 
@@ -373,6 +415,29 @@ impl Emulator {
         self.nmi_countdown = r.read_i8()?;
         self.ppu_register_warmup_until_cpu_cycle = r.read_u64()?;
         self.instructions = r.read_u64()?;
+        if r.version() >= 8 {
+            let region_byte = r.read_u8()?;
+            let saved_region = Region::from_byte(region_byte).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unknown region byte: {}", region_byte),
+                )
+            })?;
+            if saved_region != self.region.region {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "region mismatch: save={:?} current={:?}",
+                        saved_region, self.region.region
+                    ),
+                ));
+            }
+            self.master_clock_sub = r.read_u64()?;
+            self.instruction_start_sub = r.read_u64()?;
+        } else {
+            self.master_clock_sub = 0;
+            self.instruction_start_sub = 0;
+        }
         Ok(())
     }
 
@@ -443,7 +508,7 @@ impl Emulator {
         self.overlay
             .set_rewind_status(Some(format!("<< REWIND {:.1}s", secs)));
         self.overlay.draw(&mut self.buf);
-        if self.overscan {
+        if self.overscan && self.region.region != region::Region::Pal {
             self.buf.mask_overscan();
         }
         self.iohandler.render(&self.buf);
@@ -523,7 +588,11 @@ impl Emulator {
 
                 let actual_cycles = self.cpu.cycle - cycle_before;
                 let penultimate = actual_cycles.saturating_sub(2);
-                self.irq_sample_deadline = self.instruction_start_dot + penultimate * 3 + 1;
+                let deadline_sub =
+                    self.instruction_start_sub + penultimate * self.region.master_clocks_per_cpu;
+                self.irq_sample_deadline = self.instruction_start_dot
+                    + deadline_sub / self.region.master_clocks_per_ppu
+                    + 1;
 
                 // The 6502 samples the I flag on the penultimate cycle of each instruction.
                 // Most instructions that change I (CLI, SEI, PLP) do so on their last
@@ -545,7 +614,10 @@ impl Emulator {
         }
 
         let ppu_dot_before_step = self.ppu.last_synced_dot;
-        let target_dot = self.master_clock + 3;
+        self.master_clock_sub += self.region.master_clocks_per_cpu;
+        let ppu_advance = self.master_clock_sub / self.region.master_clocks_per_ppu;
+        self.master_clock_sub %= self.region.master_clocks_per_ppu;
+        let target_dot = self.master_clock + ppu_advance;
         self.sync_ppu_to_dot(target_dot);
         self.master_clock = target_dot;
 
@@ -606,7 +678,7 @@ impl Emulator {
             self.iohandler.render(&self.buf);
         }
         // ~1000 Hz input polling (1,789,773 CPU Hz / 1790 ≈ 1 ms)
-        if self.cycles % INPUT_POLL_INTERVAL == 0 {
+        if self.cycles % self.region.input_poll_interval == 0 {
             let result = self.iohandler.poll(&mut *self.mem, &mut self.apu);
             if result.exit {
                 state = CycleState::Exiting;
@@ -694,12 +766,15 @@ impl Emulator {
 
     fn begin_cpu_instruction_timing(&mut self) {
         self.instruction_start_dot = self.master_clock;
+        self.instruction_start_sub = self.master_clock_sub;
         self.cpu_bus_cycle_offset = 0;
         self.branch_irq_suppressed = false;
     }
 
     fn cpu_bus_access_dot(&self) -> u64 {
-        self.instruction_start_dot + u64::from(self.cpu_bus_cycle_offset) * 3
+        let total_sub = self.instruction_start_sub
+            + u64::from(self.cpu_bus_cycle_offset) * self.region.master_clocks_per_cpu;
+        self.instruction_start_dot + total_sub / self.region.master_clocks_per_ppu
     }
 
     /// CPU address decoded as a PPU register access, if this mapper exposes the NES PPU register bus.
@@ -933,7 +1008,9 @@ impl Emulator {
             opcodes::BRK => {
                 // Sync PPU to the vector fetch point (cycle 5 of 7) so NMI
                 // edges that arrive during BRK can hijack the vector.
-                let vector_fetch_dot = self.instruction_start_dot + 3 * 3;
+                let vf_sub = self.instruction_start_sub + 3 * self.region.master_clocks_per_cpu;
+                let vector_fetch_dot =
+                    self.instruction_start_dot + vf_sub / self.region.master_clocks_per_ppu;
                 self.sync_ppu_to_dot(vector_fetch_dot);
                 let addr = self.nmi_hijack_vector();
 
@@ -1950,7 +2027,7 @@ impl Emulator {
             }
         }
 
-        let elapsed_secs = self.cycles as f64 / 1_789_773.0;
+        let elapsed_secs = self.cycles as f64 / self.region.cpu_clock_rate;
         let fps = if elapsed_secs > 0.0 {
             self.ppu.frames as f64 / elapsed_secs
         } else {
@@ -3571,5 +3648,103 @@ mod emu_tests {
         emu.cpu.cycle = 29_658;
         emu.test_cpu_write(ppu::CTRL_REG_ADDR, 0x80);
         assert_eq!(emu.ppu.ppu_ctrl, 0x80);
+    }
+
+    #[test]
+    fn test_ntsc_master_clock_sub_always_zero() {
+        let mut emu = Emulator::_new();
+        assert_eq!(emu.region.region, region::Region::Ntsc);
+        for _ in 0..100 {
+            emu.cycle();
+            assert_eq!(emu.master_clock_sub, 0, "NTSC sub should always be 0");
+        }
+    }
+
+    #[test]
+    fn test_pal_master_clock_sub_pattern() {
+        let mapper = Box::new(memory::IdentityMapper::new(memory::CODE_START_ADDR));
+        let audio = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
+        let io = Box::new(io::HeadlessIOHandler {});
+        let mut emu = Emulator::new_with_region(io, mapper, audio, region::Region::Pal);
+        assert_eq!(emu.region.region, region::Region::Pal);
+
+        let mut total_ppu_advance: u64 = 0;
+        for i in 0..5 {
+            let before = emu.master_clock;
+            emu.cycle();
+            total_ppu_advance += emu.master_clock - before;
+            if i < 4 {
+                assert_eq!(
+                    emu.master_clock_sub,
+                    (i + 1) as u64,
+                    "sub after cycle {}",
+                    i
+                );
+            }
+        }
+        assert_eq!(emu.master_clock_sub, 0, "sub resets after 5 cycles");
+        assert_eq!(total_ppu_advance, 16, "5 PAL CPU cycles = 16 PPU dots");
+    }
+
+    #[test]
+    fn test_pal_ppu_scanline_count() {
+        let mapper = Box::new(memory::IdentityMapper::new(memory::CODE_START_ADDR));
+        let audio = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
+        let io = Box::new(io::HeadlessIOHandler {});
+        let emu = Emulator::new_with_region(io, mapper, audio, region::Region::Pal);
+        assert_eq!(emu.ppu.pre_render_scanline, 311);
+        assert_eq!(emu.ppu.num_scanlines, 312);
+    }
+
+    #[test]
+    fn test_savestate_region_roundtrip() {
+        let mapper = Box::new(memory::IdentityMapper::new(memory::CODE_START_ADDR));
+        let audio = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
+        let io = Box::new(io::HeadlessIOHandler {});
+        let mut emu = Emulator::new_with_region(io, mapper, audio, region::Region::Pal);
+        for _ in 0..100 {
+            emu.cycle();
+        }
+        let saved = emu.save_state_to_bytes();
+        let mc_before = emu.master_clock;
+        let sub_before = emu.master_clock_sub;
+
+        let mapper2 = Box::new(memory::IdentityMapper::new(memory::CODE_START_ADDR));
+        let audio2 = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
+        let io2 = Box::new(io::HeadlessIOHandler {});
+        let mut emu2 = Emulator::new_with_region(io2, mapper2, audio2, region::Region::Pal);
+        emu2.load_state_from_bytes(&saved).unwrap();
+        assert_eq!(emu2.master_clock, mc_before);
+        assert_eq!(emu2.master_clock_sub, sub_before);
+    }
+
+    #[test]
+    fn test_savestate_region_mismatch_rejected() {
+        let mapper = Box::new(memory::IdentityMapper::new(memory::CODE_START_ADDR));
+        let audio = Box::new(SilentAudioOutput::new()) as Box<dyn AudioBackend>;
+        let io = Box::new(io::HeadlessIOHandler {});
+        let emu = Emulator::new_with_region(io, mapper, audio, region::Region::Pal);
+        let saved = emu.save_state_to_bytes();
+
+        let mut emu_ntsc = Emulator::_new();
+        let result = emu_ntsc.load_state_from_bytes(&saved);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("region mismatch"));
+    }
+
+    #[test]
+    fn test_savestate_v7_loads_as_ntsc() {
+        let mut emu = Emulator::_new();
+        for _ in 0..100 {
+            emu.cycle();
+        }
+        let saved = emu.save_state_to_bytes();
+        // Patch version byte back to 7 and strip the 3 new fields (u8 + u64 + u64 = 17 bytes)
+        let mut v7_data = saved[..saved.len() - 17].to_vec();
+        v7_data[4] = 7;
+        let mut emu2 = Emulator::_new();
+        emu2.load_state_from_bytes(&v7_data).unwrap();
+        assert_eq!(emu2.master_clock_sub, 0);
+        assert_eq!(emu2.instruction_start_sub, 0);
     }
 }

--- a/core/src/emu/ppu/mod.rs
+++ b/core/src/emu/ppu/mod.rs
@@ -302,10 +302,18 @@ pub struct PPU {
     /// PPU dot of the most recent nmi_output rising edge.
     /// Cleared when nmi_output goes back to false (cancels the edge before the CPU samples it).
     pub nmi_rising_edge_dot: Option<u64>,
+
+    pub(crate) pre_render_scanline: u16,
+    pub(crate) num_scanlines: u16,
+    odd_frame_skip_enabled: bool,
 }
 
 impl PPU {
     pub fn new() -> PPU {
+        Self::new_with_region(&crate::emu::region::Region::Ntsc.config())
+    }
+
+    pub fn new_with_region(region: &crate::emu::region::RegionConfig) -> PPU {
         let oam_ram = Box::new([0; OAM_DATA_SIZE]);
 
         PPU {
@@ -366,6 +374,10 @@ impl PPU {
             nmi_suppress_next_vblank: false,
             nmi_output: false,
             nmi_rising_edge_dot: None,
+
+            pre_render_scanline: region.pre_render_scanline,
+            num_scanlines: region.num_scanlines,
+            odd_frame_skip_enabled: region.odd_frame_skip,
         }
     }
 
@@ -606,7 +618,7 @@ impl PPU {
             OAM_DATA_ADDR => {
                 // During active rendering, OAMDATA writes do not store to OAM; OAMADDR glitches forward
                 // (high 6 bits increment) per nesdev Wiki/OAM.
-                let rendering = (self.scanline == PRE_RENDER_SCANLINE
+                let rendering = (self.scanline == self.pre_render_scanline
                     || self.scanline < SCREEN_HEIGHT as u16)
                     && (self.ppu_mask & (MASK_BACKGROUND_ENABLE | MASK_SPRITES_ENABLE)) != 0;
                 if rendering {
@@ -709,15 +721,16 @@ impl PPU {
         // Latch BG-enable at pre-render dot 337 for the odd-frame skip decision.
         // The skip is at dot 339 but the CPU write that toggles BG on the same
         // CPU cycle (dots 337-339) must not affect this frame's skip.
-        if self.scanline == PRE_RENDER_SCANLINE && self.cycle == CYCLES_PER_SCANLINE - 3 {
-            self.odd_frame_skip_pending = self.frames % 2 == 1
+        if self.scanline == self.pre_render_scanline && self.cycle == CYCLES_PER_SCANLINE - 3 {
+            self.odd_frame_skip_pending = self.odd_frame_skip_enabled
+                && self.frames % 2 == 1
                 && (self.ppu_mask & MASK_BACKGROUND_ENABLE == MASK_BACKGROUND_ENABLE);
         }
 
         self.cycle = self.cycle.wrapping_add(1);
         if self.cycle > CYCLES_PER_SCANLINE {
             self.cycle = 0;
-            self.scanline = self.scanline.wrapping_add(1) % NUM_SCANLINES;
+            self.scanline = self.scanline.wrapping_add(1) % self.num_scanlines;
             if self.scanline == 0 {
                 self.frames += 1;
             }
@@ -746,7 +759,7 @@ impl PPU {
 
         let rendering_enabled = self.mask_background_enabled() || self.mask_sprites_enabled();
         let rendering_scanline =
-            self.scanline < SCREEN_HEIGHT as u16 || self.scanline == PRE_RENDER_SCANLINE;
+            self.scanline < SCREEN_HEIGHT as u16 || self.scanline == self.pre_render_scanline;
 
         let mut result = StepResult::default();
 
@@ -827,7 +840,7 @@ impl PPU {
         }
 
         // PPUSTATUS bits 5–7 (O, S, V) clear at dot 1 of prerender; games poll sprite 0 hit across frames.
-        if self.scanline == PRE_RENDER_SCANLINE && self.cycle == FIRST_VISIBLE_DOT {
+        if self.scanline == self.pre_render_scanline && self.cycle == FIRST_VISIBLE_DOT {
             self.ppu_status &= !STATUS_VERTICAL_BLANK_BIT;
             self.ppu_status &= !STATUS_SPRITE_ZERO_HIT;
             self.ppu_status &= !STATUS_SPRITE_OVERFLOW;
@@ -855,7 +868,7 @@ impl PPU {
                 self.next_render_line_v = self.v;
             }
 
-            if self.scanline == PRE_RENDER_SCANLINE
+            if self.scanline == self.pre_render_scanline
                 && self.cycle >= VSCROLL_COPY_START
                 && self.cycle <= VSCROLL_COPY_END
             {
@@ -1073,7 +1086,7 @@ impl PPU {
         self.next_render_line_v = self.v;
 
         let rendering_scanline =
-            self.scanline < SCREEN_HEIGHT as u16 || self.scanline == PRE_RENDER_SCANLINE;
+            self.scanline < SCREEN_HEIGHT as u16 || self.scanline == self.pre_render_scanline;
         let rendering_enabled = self.mask_background_enabled() || self.mask_sprites_enabled();
         if rendering_scanline
             && rendering_enabled
@@ -1195,7 +1208,7 @@ impl PPU {
     }
 
     fn sprite_eval_target_scanline(&self) -> u16 {
-        if self.scanline == PRE_RENDER_SCANLINE {
+        if self.scanline == self.pre_render_scanline {
             0
         } else {
             self.scanline.wrapping_add(1)
@@ -2488,7 +2501,7 @@ mod tests {
         mem.ppu_write(UNIVERSAL_BG_COLOR_ADDR as u16 + 1, 3);
 
         let lit_color = palette::PALETTE[3];
-        let dots_per_frame: u32 = 341 * 262;
+        let dots_per_frame: u32 = 341 * NUM_SCANLINES as u32;
 
         // Frame 1: scroll_y = 3 (fine_y=3, coarse_y=0)
         ppu.t = 3u16 << V_FINE_Y_SHIFT;
@@ -2580,7 +2593,7 @@ mod tests {
 
         let white = palette::PALETTE[0x30];
 
-        let dots_per_frame: u32 = 341 * 262;
+        let dots_per_frame: u32 = 341 * NUM_SCANLINES as u32;
 
         // Start scrolling down from scroll_y = 10, then scroll upward
         // scroll_y=10 means coarse_y=1, fine_y=2

--- a/core/src/emu/region.rs
+++ b/core/src/emu/region.rs
@@ -1,0 +1,117 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Region {
+    Ntsc,
+    Pal,
+}
+
+impl std::fmt::Display for Region {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Region::Ntsc => write!(f, "NTSC"),
+            Region::Pal => write!(f, "PAL"),
+        }
+    }
+}
+
+impl Region {
+    pub fn config(self) -> RegionConfig {
+        match self {
+            Region::Ntsc => RegionConfig {
+                region: Region::Ntsc,
+                master_clocks_per_cpu: 12,
+                master_clocks_per_ppu: 4,
+                num_scanlines: 262,
+                pre_render_scanline: 261,
+                vblank_scanline: 241,
+                cpu_clock_rate: 1_789_773.0,
+                frame_duration_nanos: 16_639_267,
+                odd_frame_skip: true,
+                input_poll_interval: 1790,
+            },
+            Region::Pal => RegionConfig {
+                region: Region::Pal,
+                master_clocks_per_cpu: 16,
+                master_clocks_per_ppu: 5,
+                num_scanlines: 312,
+                pre_render_scanline: 311,
+                vblank_scanline: 241,
+                cpu_clock_rate: 1_662_607.0,
+                frame_duration_nanos: 19_997_200,
+                odd_frame_skip: false,
+                input_poll_interval: 1663,
+            },
+        }
+    }
+
+    pub fn to_byte(self) -> u8 {
+        match self {
+            Region::Ntsc => 0,
+            Region::Pal => 1,
+        }
+    }
+
+    pub fn from_byte(b: u8) -> Option<Region> {
+        match b {
+            0 => Some(Region::Ntsc),
+            1 => Some(Region::Pal),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RegionConfig {
+    pub region: Region,
+    pub master_clocks_per_cpu: u64,
+    pub master_clocks_per_ppu: u64,
+    pub num_scanlines: u16,
+    pub pre_render_scanline: u16,
+    pub vblank_scanline: u16,
+    pub cpu_clock_rate: f64,
+    pub frame_duration_nanos: u64,
+    pub odd_frame_skip: bool,
+    pub input_poll_interval: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ntsc_config() {
+        let c = Region::Ntsc.config();
+        assert_eq!(c.master_clocks_per_cpu, 12);
+        assert_eq!(c.master_clocks_per_ppu, 4);
+        assert_eq!(c.num_scanlines, 262);
+        assert_eq!(c.pre_render_scanline, 261);
+        assert!(c.odd_frame_skip);
+        assert_eq!(c.master_clocks_per_cpu / c.master_clocks_per_ppu, 3);
+    }
+
+    #[test]
+    fn test_pal_config() {
+        let c = Region::Pal.config();
+        assert_eq!(c.master_clocks_per_cpu, 16);
+        assert_eq!(c.master_clocks_per_ppu, 5);
+        assert_eq!(c.num_scanlines, 312);
+        assert_eq!(c.pre_render_scanline, 311);
+        assert!(!c.odd_frame_skip);
+    }
+
+    #[test]
+    fn test_pal_ppu_cpu_ratio() {
+        let c = Region::Pal.config();
+        let ppu_dots_per_5_cpu = 5 * c.master_clocks_per_cpu / c.master_clocks_per_ppu;
+        assert_eq!(ppu_dots_per_5_cpu, 16);
+    }
+
+    #[test]
+    fn test_region_byte_roundtrip() {
+        assert_eq!(
+            Region::from_byte(Region::Ntsc.to_byte()),
+            Some(Region::Ntsc)
+        );
+        assert_eq!(Region::from_byte(Region::Pal.to_byte()), Some(Region::Pal));
+        assert_eq!(Region::from_byte(255), None);
+    }
+}

--- a/core/src/emu/savestate.rs
+++ b/core/src/emu/savestate.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 const MAGIC: &[u8; 4] = b"KRNK";
-const VERSION: u8 = 7;
+const VERSION: u8 = 8;
 
 pub struct SavestateWriter {
     buf: Vec<u8>,

--- a/desktop/src/io/gtk_backend.rs
+++ b/desktop/src/io/gtk_backend.rs
@@ -18,7 +18,7 @@ use krankulator_core::emu::memory;
 
 use super::{
     add_recent_rom, apply_gamepad, build_menu_contents, frame_pace, open_rom_dialog,
-    populate_recent_submenu, MenuIds, MenuItems,
+    populate_recent_submenu, MenuIds, MenuItems, NTSC_FRAME_DURATION,
 };
 use crate::gamepad::Gamepads;
 use crate::settings;
@@ -114,6 +114,7 @@ pub struct GtkPixelsIOHandler {
     muted: Rc<Cell<bool>>,
     last_frame_time: Instant,
     last_frame_ms: f64,
+    frame_duration: Duration,
     kb_state: Rc<Cell<u8>>,
     fast_forward: Rc<Cell<bool>>,
     pixel_perfect: Rc<Cell<bool>>,
@@ -300,6 +301,7 @@ impl GtkPixelsIOHandler {
             muted,
             last_frame_time: Instant::now(),
             last_frame_ms: 0.0,
+            frame_duration: NTSC_FRAME_DURATION,
             kb_state,
             fast_forward,
             pixel_perfect,
@@ -816,8 +818,23 @@ impl IOHandler for GtkPixelsIOHandler {
         Some(self.last_frame_ms)
     }
 
+    fn set_frame_duration_nanos(&mut self, nanos: u64) {
+        self.frame_duration = Duration::from_nanos(nanos);
+    }
+
+    fn set_overscan_available(&mut self, available: bool) {
+        self.menu_items.overscan.set_enabled(available);
+        if !available {
+            self.overscan.set(false);
+        }
+    }
+
     fn render(&mut self, buf: &gfx::buf::Buffer) {
-        self.last_frame_ms = frame_pace(&mut self.last_frame_time, self.fast_forward.get());
+        self.last_frame_ms = frame_pace(
+            &mut self.last_frame_time,
+            self.fast_forward.get(),
+            self.frame_duration,
+        );
 
         {
             let mut rgba = self.rgba_buf.borrow_mut();

--- a/desktop/src/io/gtk_backend.rs
+++ b/desktop/src/io/gtk_backend.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, RefCell};
 use std::ffi::CStr;
 use std::process::Command;
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use gdk::keys::constants as gdk_key;
 use gdk::prelude::*;

--- a/desktop/src/io/mod.rs
+++ b/desktop/src/io/mod.rs
@@ -21,7 +21,7 @@ use krankulator_core::emu::memory;
 
 use crate::gamepad::Gamepads;
 
-const NES_FRAME_DURATION: Duration = Duration::from_nanos(16_639_267);
+pub(crate) const NTSC_FRAME_DURATION: Duration = Duration::from_nanos(16_639_267);
 
 pub(crate) static ICON_PNG: &[u8] = include_bytes!("../../assets/icon.png");
 
@@ -315,15 +315,19 @@ pub(crate) fn apply_gamepad(
     }
 }
 
-pub(crate) fn frame_pace(last_frame_time: &mut Instant, fast_forward: bool) -> f64 {
+pub(crate) fn frame_pace(
+    last_frame_time: &mut Instant,
+    fast_forward: bool,
+    frame_duration: Duration,
+) -> f64 {
     let elapsed = last_frame_time.elapsed();
     let frame_ms = elapsed.as_secs_f64() * 1000.0;
-    if !fast_forward && elapsed < NES_FRAME_DURATION {
-        let sleep_duration = NES_FRAME_DURATION - elapsed;
+    if !fast_forward && elapsed < frame_duration {
+        let sleep_duration = frame_duration - elapsed;
         if sleep_duration > Duration::from_millis(1) {
             std::thread::sleep(sleep_duration - Duration::from_millis(1));
         }
-        while last_frame_time.elapsed() < NES_FRAME_DURATION {
+        while last_frame_time.elapsed() < frame_duration {
             std::hint::spin_loop();
         }
     }
@@ -393,7 +397,7 @@ mod tests {
     #[test]
     fn test_frame_pace_fast_forward_skips_sleep() {
         let mut t = Instant::now();
-        let ms = frame_pace(&mut t, true);
+        let ms = frame_pace(&mut t, true, NTSC_FRAME_DURATION);
         assert!(ms < 1.0);
     }
 
@@ -401,7 +405,7 @@ mod tests {
     fn test_frame_pace_normal_sleeps_to_frame_budget() {
         let mut t = Instant::now();
         let before = Instant::now();
-        frame_pace(&mut t, false);
+        frame_pace(&mut t, false, NTSC_FRAME_DURATION);
         let wall = before.elapsed();
         assert!(
             wall.as_millis() >= 14,

--- a/desktop/src/io/winit_backend.rs
+++ b/desktop/src/io/winit_backend.rs
@@ -23,7 +23,7 @@ use krankulator_core::util;
 
 use super::{
     add_recent_rom, apply_gamepad, build_menu_contents, frame_pace, open_rom_dialog,
-    populate_recent_submenu, MenuIds, MenuItems,
+    populate_recent_submenu, MenuIds, MenuItems, NTSC_FRAME_DURATION,
 };
 use crate::gamepad::Gamepads;
 use crate::settings::{self, Settings};
@@ -60,6 +60,7 @@ pub struct WinitPixelsIOHandler {
     scanlines: bool,
     overscan: bool,
     crt: Option<CrtPipeline>,
+    frame_duration: Duration,
     _menu: Menu,
     menu_ids: MenuIds,
     menu_items: MenuItems,
@@ -171,6 +172,7 @@ impl WinitPixelsIOHandler {
             scanlines: settings.scanlines,
             overscan: settings.overscan,
             crt,
+            frame_duration: NTSC_FRAME_DURATION,
             _menu: menu,
             menu_ids,
             menu_items,
@@ -736,8 +738,23 @@ impl IOHandler for WinitPixelsIOHandler {
         Some(self.last_frame_ms)
     }
 
+    fn set_frame_duration_nanos(&mut self, nanos: u64) {
+        self.frame_duration = Duration::from_nanos(nanos);
+    }
+
+    fn set_overscan_available(&mut self, available: bool) {
+        self.menu_items.overscan.set_enabled(available);
+        if !available {
+            self.overscan = false;
+        }
+    }
+
     fn render(&mut self, buf: &gfx::buf::Buffer) {
-        self.last_frame_ms = frame_pace(&mut self.last_frame_time, self.fast_forward);
+        self.last_frame_ms = frame_pace(
+            &mut self.last_frame_time,
+            self.fast_forward,
+            self.frame_duration,
+        );
 
         let window = self.window.unwrap();
         let pixels = self.pixels.as_mut().unwrap();

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5,7 +5,7 @@ pub(crate) mod settings;
 
 use std::io::Read;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use krankulator_core::emu;
 use krankulator_core::emu::io::loader;
 use krankulator_core::util;
@@ -89,19 +89,19 @@ struct Args {
     wav_out: Option<String>,
 
     /// Region: auto, ntsc, pal
-    #[clap(long, default_value = "auto")]
-    region: String,
+    #[clap(long, value_enum, ignore_case = true, default_value_t = RegionArg::Auto)]
+    region: RegionArg,
 
     /// Input file to use
     #[clap()]
     input: Option<String>,
 }
 
-fn resolve_region(cli: &str) -> emu::Region {
-    match cli {
-        "pal" => emu::Region::Pal,
-        _ => emu::Region::Ntsc,
-    }
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum RegionArg {
+    Auto,
+    Ntsc,
+    Pal,
 }
 
 fn detect_region_from_file(path: &str) -> emu::Region {
@@ -143,14 +143,14 @@ fn main() -> Result<(), String> {
             }
             "nes" => match load_rom_file(input) {
                 Ok(mapper) => {
-                    let region = if args.region == "auto" {
-                        detect_region_from_file(input)
-                    } else {
-                        resolve_region(&args.region)
+                    let region = match args.region {
+                        RegionArg::Auto => detect_region_from_file(input),
+                        RegionArg::Ntsc => emu::Region::Ntsc,
+                        RegionArg::Pal => emu::Region::Pal,
                     };
                     println!("Region: {}", region);
                     let mut emu: emu::Emulator = if args.wav_out.is_some() {
-                        emu::Emulator::new_capturing(mapper)
+                        emu::Emulator::new_capturing_with_region(mapper, region)
                     } else if !args.headless {
                         let audio = Box::new(
                             audio::AudioOutput::try_new(emu::apu::SAMPLE_RATE)
@@ -164,7 +164,7 @@ fn main() -> Result<(), String> {
                             Box::new(io::PlatformIOHandler::new(256, 240, rom_name, &settings));
                         emu::Emulator::new_with_region(io, mapper, audio, region)
                     } else {
-                        emu::Emulator::new_headless(mapper)
+                        emu::Emulator::new_headless_with_region(mapper, region)
                     };
 
                     emu.cpu.status = 0x34;
@@ -231,10 +231,10 @@ fn main() -> Result<(), String> {
         match emu.take_pending_open_rom() {
             Some(path) => match load_rom_file(&path) {
                 Ok(mapper) => {
-                    let region = if args.region == "auto" {
-                        detect_region_from_file(&path)
-                    } else {
-                        resolve_region(&args.region)
+                    let region = match args.region {
+                        RegionArg::Auto => detect_region_from_file(&path),
+                        RegionArg::Ntsc => emu::Region::Ntsc,
+                        RegionArg::Pal => emu::Region::Pal,
                     };
                     println!("Region: {}", region);
                     emu.load_rom_with_region(mapper, &path, region);

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -88,9 +88,37 @@ struct Args {
     #[clap(long)]
     wav_out: Option<String>,
 
+    /// Region: auto, ntsc, pal
+    #[clap(long, default_value = "auto")]
+    region: String,
+
     /// Input file to use
     #[clap()]
     input: Option<String>,
+}
+
+fn resolve_region(cli: &str) -> emu::Region {
+    match cli {
+        "pal" => emu::Region::Pal,
+        _ => emu::Region::Ntsc,
+    }
+}
+
+fn detect_region_from_file(path: &str) -> emu::Region {
+    let filename = std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str());
+    if path.to_lowercase().ends_with(".zip") {
+        match extract_nes_from_zip(path) {
+            Ok(bytes) => loader::detect_region_with_filename(&bytes, filename),
+            Err(_) => emu::Region::Ntsc,
+        }
+    } else {
+        match std::fs::read(path) {
+            Ok(bytes) => loader::detect_region_with_filename(&bytes, filename),
+            Err(_) => emu::Region::Ntsc,
+        }
+    }
 }
 
 fn main() -> Result<(), String> {
@@ -115,6 +143,12 @@ fn main() -> Result<(), String> {
             }
             "nes" => match load_rom_file(input) {
                 Ok(mapper) => {
+                    let region = if args.region == "auto" {
+                        detect_region_from_file(input)
+                    } else {
+                        resolve_region(&args.region)
+                    };
+                    println!("Region: {}", region);
                     let mut emu: emu::Emulator = if args.wav_out.is_some() {
                         emu::Emulator::new_capturing(mapper)
                     } else if !args.headless {
@@ -128,7 +162,7 @@ fn main() -> Result<(), String> {
                             .unwrap_or(input);
                         let io =
                             Box::new(io::PlatformIOHandler::new(256, 240, rom_name, &settings));
-                        emu::Emulator::new_with(io, mapper, audio)
+                        emu::Emulator::new_with_region(io, mapper, audio, region)
                     } else {
                         emu::Emulator::new_headless(mapper)
                     };
@@ -197,7 +231,13 @@ fn main() -> Result<(), String> {
         match emu.take_pending_open_rom() {
             Some(path) => match load_rom_file(&path) {
                 Ok(mapper) => {
-                    emu.load_rom(mapper, &path);
+                    let region = if args.region == "auto" {
+                        detect_region_from_file(&path)
+                    } else {
+                        resolve_region(&args.region)
+                    };
+                    println!("Region: {}", region);
+                    emu.load_rom_with_region(mapper, &path, region);
                     io::add_recent_rom(&path);
                 }
                 Err(msg) => {

--- a/libretro/src/lib.rs
+++ b/libretro/src/lib.rs
@@ -16,7 +16,8 @@ use std::rc::Rc;
 
 const NES_WIDTH: c_uint = 256;
 const NES_HEIGHT: c_uint = 240;
-const NES_FPS: f64 = 60.0988;
+const NTSC_FPS: f64 = 60.0988;
+const PAL_FPS: f64 = 50.0070;
 const SAMPLE_RATE: f64 = 44100.0;
 const SERIALIZE_MAX_SIZE: usize = 256 * 1024;
 
@@ -38,6 +39,7 @@ struct RetroState {
     frame_buf: Rc<RefCell<Vec<u32>>>,
     audio_buf: Rc<RefCell<Vec<i16>>>,
     has_battery: bool,
+    region: emu::Region,
 }
 
 static mut STATE: Option<RetroState> = None;
@@ -212,8 +214,12 @@ pub unsafe extern "C" fn retro_get_system_av_info(info: *mut RetroSystemAvInfo) 
         max_height: NES_HEIGHT,
         aspect_ratio: 4.0 / 3.0,
     };
+    let fps = match STATE.as_ref().map(|s| s.region) {
+        Some(emu::Region::Pal) => PAL_FPS,
+        _ => NTSC_FPS,
+    };
     (*info).timing = RetroSystemTiming {
-        fps: NES_FPS,
+        fps,
         sample_rate: SAMPLE_RATE,
     };
 }
@@ -286,6 +292,14 @@ pub unsafe extern "C" fn retro_load_game(game: *const RetroGameInfo) -> bool {
 
     let rom_data = std::slice::from_raw_parts((*game).data as *const u8, (*game).size);
 
+    let path = if (*game).path.is_null() {
+        None
+    } else {
+        std::ffi::CStr::from_ptr((*game).path).to_str().ok()
+    };
+    let filename = path.and_then(|p| p.rsplit('/').next());
+    let region = loader::detect_region_with_filename(rom_data, filename);
+
     let has_battery = loader::rom_has_battery(rom_data);
 
     let mapper = match loader::load_nes_from_bytes(rom_data) {
@@ -303,7 +317,7 @@ pub unsafe extern "C" fn retro_load_game(game: *const RetroGameInfo) -> bool {
         buf: Rc::clone(&audio_buf),
     });
 
-    let mut emulator = emu::Emulator::new_with(io, mapper, audio);
+    let mut emulator = emu::Emulator::new_with_region(io, mapper, audio, region);
     emulator.cpu.status = 0x34;
     emulator.cpu.sp = 0xfd;
     emulator.toggle_should_trigger_nmi(true);
@@ -311,6 +325,7 @@ pub unsafe extern "C" fn retro_load_game(game: *const RetroGameInfo) -> bool {
 
     STATE = Some(RetroState {
         emulator,
+        region,
         frame_buf,
         audio_buf,
         has_battery,
@@ -446,7 +461,10 @@ pub unsafe extern "C" fn retro_get_memory_size(id: c_uint) -> usize {
 
 #[no_mangle]
 pub unsafe extern "C" fn retro_get_region() -> c_uint {
-    RETRO_REGION_NTSC
+    match STATE.as_ref().map(|s| s.region) {
+        Some(emu::Region::Pal) => RETRO_REGION_PAL,
+        _ => RETRO_REGION_NTSC,
+    }
 }
 
 #[no_mangle]

--- a/libretro/src/lib.rs
+++ b/libretro/src/lib.rs
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn retro_load_game(game: *const RetroGameInfo) -> bool {
     } else {
         std::ffi::CStr::from_ptr((*game).path).to_str().ok()
     };
-    let filename = path.and_then(|p| p.rsplit('/').next());
+    let filename = path.and_then(|p| p.rsplit(&['/', '\\'][..]).next());
     let region = loader::detect_region_with_filename(rom_data, filename);
 
     let has_battery = loader::rom_has_battery(rom_data);

--- a/libretro/src/libretro_sys.rs
+++ b/libretro/src/libretro_sys.rs
@@ -3,6 +3,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 pub const RETRO_API_VERSION: c_uint = 1;
 
 pub const RETRO_REGION_NTSC: c_uint = 0;
+pub const RETRO_REGION_PAL: c_uint = 1;
 
 pub const RETRO_MEMORY_SAVE_RAM: c_uint = 0;
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -80,12 +80,13 @@ fn setup_file_input() {
         let reader = web_sys::FileReader::new().unwrap();
         let reader_clone = reader.clone();
 
+        let file_name = file.name();
         let onload = Closure::wrap(Box::new(move |_: web_sys::Event| {
             let array_buffer = reader_clone.result().unwrap();
             let uint8_array = js_sys::Uint8Array::new(&array_buffer);
             let mut rom_data = vec![0u8; uint8_array.length() as usize];
             uint8_array.copy_to(&mut rom_data);
-            start_emulator(rom_data);
+            start_emulator(rom_data, Some(file_name.clone()));
         }) as Box<dyn FnMut(_)>);
 
         reader.set_onload(Some(onload.as_ref().unchecked_ref()));
@@ -106,7 +107,7 @@ fn setup_lucky_button() {
         set_status("Fetching ROM...");
         wasm_bindgen_futures::spawn_local(async {
             match fetch_rom("https://file.classicjoy.games/games/meta-man/mega-man-2.nes").await {
-                Ok(data) => start_emulator(data),
+                Ok(data) => start_emulator(data, None),
                 Err(e) => set_status(&format!("Failed to fetch: {}", e)),
             }
         });
@@ -161,7 +162,7 @@ fn setup_touch_lucky_button() {
     let closure = Closure::wrap(Box::new(move |_: web_sys::Event| {
         wasm_bindgen_futures::spawn_local(async {
             match fetch_rom("https://file.classicjoy.games/games/meta-man/mega-man-2.nes").await {
-                Ok(data) => start_emulator(data),
+                Ok(data) => start_emulator(data, None),
                 Err(e) => set_status(&format!("Failed to fetch: {}", e)),
             }
         });
@@ -192,8 +193,10 @@ async fn fetch_rom(url: &str) -> Result<Vec<u8>, String> {
     Ok(data)
 }
 
-fn start_emulator(rom_data: Vec<u8>) {
+fn start_emulator(rom_data: Vec<u8>, filename: Option<String>) {
     GENERATION.with(|g| g.set(g.get().wrapping_add(1)));
+
+    let region = loader::detect_region_with_filename(&rom_data, filename.as_deref());
 
     let rom_hash = hash_rom(&rom_data);
     let has_battery = loader::rom_has_battery(&rom_data);
@@ -227,13 +230,14 @@ fn start_emulator(rom_data: Vec<u8>) {
         worklet_level.clone(),
     ));
 
-    let mut emu = emu::Emulator::new_with(io_handler, mapper, audio_backend);
+    let is_pal = region == emu::Region::Pal;
+    let mut emu = emu::Emulator::new_with_region(io_handler, mapper, audio_backend, region);
     emu.cpu.status = 0x34;
     emu.cpu.sp = 0xfd;
     emu.toggle_should_trigger_nmi(true);
     emu.toggle_should_exit_on_infinite_loop(false);
     emu.toggle_quiet_mode(true);
-    emu.set_overscan(true);
+    emu.set_overscan(!is_pal);
 
     if let Err(msg) = emu.init() {
         set_status(&format!("Init failed: {}", msg));
@@ -253,11 +257,17 @@ fn start_emulator(rom_data: Vec<u8>) {
     setup_beforeunload_sram(rom_hash, has_battery, gen);
     wasm_bindgen_futures::spawn_local(async move {
         audio::connect_audio_worklet(audio_ctx, audio_port, worklet_level).await;
-        run_loop(emu, gen, keys, rom_hash_clone, has_battery);
+        let frame_duration_ms = region.config().frame_duration_nanos as f64 / 1_000_000.0;
+        run_loop(
+            emu,
+            gen,
+            keys,
+            rom_hash_clone,
+            has_battery,
+            frame_duration_ms,
+        );
     });
 }
-
-const FRAME_DURATION_MS: f64 = 1000.0 / 60.0988;
 
 fn run_loop(
     mut emu: emu::Emulator,
@@ -265,6 +275,7 @@ fn run_loop(
     keys: Rc<RefCell<HashSet<String>>>,
     rom_hash: String,
     has_battery: bool,
+    frame_duration_ms: f64,
 ) {
     let f: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
     let g = f.clone();
@@ -300,7 +311,7 @@ fn run_loop(
         let max_frames = if fast_forward { 20 } else { 2 };
 
         let mut frames_run = 0;
-        while time_accumulator >= FRAME_DURATION_MS && frames_run < max_frames {
+        while time_accumulator >= frame_duration_ms && frames_run < max_frames {
             let emu_start = perf.now();
             if !emu.run_one_frame() {
                 set_status("Emulator stopped");
@@ -308,11 +319,11 @@ fn run_loop(
             }
             let emu_ms = perf.now() - emu_start;
             emu.overlay.set_frame_time(emu_ms);
-            time_accumulator -= FRAME_DURATION_MS;
+            time_accumulator -= frame_duration_ms;
             frames_run += 1;
         }
 
-        if time_accumulator > FRAME_DURATION_MS * 3.0 {
+        if time_accumulator > frame_duration_ms * 3.0 {
             time_accumulator = 0.0;
         }
 


### PR DESCRIPTION
## Summary

Adds full PAL (European) NES region support to the emulator. PAL NES hardware uses different clock dividers than NTSC, producing a non-integer 3.2:1 PPU-to-CPU ratio (vs NTSC's clean 3:1), 312 scanlines per frame (vs 262), and a ~50 Hz frame rate (vs ~60 Hz).

### Master clock sub-dot accumulator

The core challenge is PAL's fractional PPU:CPU ratio. NTSC advances 3 PPU dots per CPU cycle. PAL needs 3.2 dots — not representable as an integer.

Solution: track timing in master clock ticks using integer dividers. NTSC master clock = 12 ticks per CPU cycle, 4 per PPU dot (12/4 = 3). PAL = 16 ticks per CPU cycle, 5 per PPU dot (16/5 = 3.2). A `master_clock_sub` accumulator tracks the fractional remainder, producing the PAL pattern: 3, 3, 3, 3, 4 PPU dots over 5 CPU cycles. Pure integer math, no floats.

### Region detection

- NES 2.0 header byte 12 (authoritative, returns immediately)
- iNES 1.0 header byte 9 (unreliable, falls through to filename)
- Filename heuristic: `(E)`, `(Europe)`, `(PAL)` case-insensitive
- Desktop CLI: `--region auto|ntsc|pal` (default: auto)

### What changed

- **Region config** (`core/src/emu/region.rs`): `Region` enum + `RegionConfig` struct with all timing parameters
- **Emulator core**: master clock sub-dot accumulator, region-aware constructors, PPU dot calculation via integer division
- **PPU**: configurable scanline count (262/312), pre-render scanline, odd-frame skip (NTSC only)
- **APU**: PAL frame counter tables, noise period table, DMC rate table, region-aware sample rate
- **Savestate v8**: persists region byte + sub-dot state. V7 loads assume NTSC. V8 rejects region mismatch
- **Desktop**: `--region` CLI flag, region-aware frame pacing, overscan menu greyed out for PAL
- **Web**: region detection from ROM bytes + filename, region-aware rAF frame duration
- **Libretro**: region detection, correct FPS in `retro_get_system_av_info()`, `RETRO_REGION_PAL`
- **Overlay**: frame budget percentage uses region-appropriate target (16.64ms NTSC / 20.00ms PAL)
- **Overscan**: skipped for PAL in core (PAL TVs show full 240 lines)

### PAL timing parameters

| | NTSC | PAL |
|--|------|-----|
| Master clocks per CPU | 12 | 16 |
| Master clocks per PPU dot | 4 | 5 |
| PPU dots per CPU cycle | 3 | 3.2 |
| Scanlines per frame | 262 | 312 |
| Frame rate | 60.0988 Hz | 50.0070 Hz |
| CPU clock rate | 1,789,773 Hz | 1,662,607 Hz |
| Odd-frame skip | Yes | No |

## Test plan

- [x] All 557 tests pass (551 core + 6 desktop, 21 ignored)
- [x] 10 PAL APU tests unignored and passing (were using NTSC constructor)
- [x] Savestate v7 backward compatibility (loads as NTSC)
- [x] Savestate v8 region mismatch rejection
- [x] PAL sub-dot pattern verified: 3,3,3,3,4 over 5 CPU cycles
- [x] Exit FPS reports correct value for PAL (~50 Hz)
- [x] Desktop `--region pal` tested with PAL ROMs
- [x] Run NTSC audio reference tests (`cargo test --release test_apu_mixer -- --ignored`)