### PR TITLE
Add turbo A/B buttons and revise gamepad bindings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ cargo clippy --workspace
 
 **Rewind (`emu/rewind.rs`)**
 - `RewindBuffer`: ring buffer of savestate + framebuffer pairs (300 slots = 10s at 30fps capture rate)
-- Captures every other frame to give 2x rewind speed. Rewind activated via `PollResult.rewind` (W key or right trigger)
+- Captures every other frame to give 2x rewind speed. Rewind activated via `PollResult.rewind` (W key or LT trigger)
 - During rewind, emulation is paused; frames are popped and rendered with overlay showing remaining time
 
 **IO (`emu/io/`)**
@@ -189,14 +189,14 @@ cargo clippy --workspace
 
 - `main.rs` — CLI (clap), wires IOHandler + AudioBackend to core; `--region auto|ntsc|pal` flag; region auto-detection from header + filename; no-ROM launch shows banner screen; outer loop handles Open ROM by reloading mapper and re-entering `run()`; unsupported mapper errors toast on-screen
 - `debug_ui.rs` — egui 0.34 debug panels (F12 toggle, P to pause). Left panel: scrolling disassembly (10+10 lines around PC) and 4 nametables in 2x2 grid with scroll viewport overlay. Right panel: CPU registers, PPU state, APU oscilloscope waveforms, and sprite tile grid. Window widens by 2×PANEL_WIDTH when active. macOS/Windows only (wgpu/egui); not available on Linux GTK backend.
-- `bindings.rs` — Configurable input bindings data model: `Action` enum (27 variants for P1/P2 NES buttons + system actions), `KeyId` (platform-agnostic key identifier using winit KeyCode names), `GamepadButtonId` (gilrs Button variant names), `InputBindings` struct with keyboard and gamepad binding vectors. Default bindings reproduce previous hardcoded behavior. `controller_bit()` maps NES button actions to (player, bit) pairs.
+- `bindings.rs` — Configurable input bindings data model: `Action` enum (33 variants for P1/P2 NES buttons, turbo buttons + system actions), `KeyId` (platform-agnostic key identifier using winit KeyCode names), `GamepadButtonId` (gilrs Button variant names), `InputBindings` struct with keyboard and gamepad binding vectors. Default bindings reproduce previous hardcoded behavior. `controller_bit()` maps NES button actions to (player, bit) pairs; `turbo_controller_bit()` does the same for turbo variants.
 - `bindings_ui.rs` — Press-to-bind overlay UI drawn on the NES framebuffer using the 8x8 font. State machine: SelectAction (scrollable list) → ActionMenu (Set Key/Set Button/Restore Default/Back) → WaitingForInput (captures next key or gamepad button press). Activated via F10 or Emulation → Input Settings menu item. Game continues rendering but controller input is zeroed while UI is active.
 - `settings.rs` — Persistent settings (`~/.config/krankulator/settings.txt`): `integer_scaling`, `scanlines`, `overscan`, `correct_aspect_ratio`, `window_scale`, input bindings. Simple key=value format, no serde. Bindings serialized as `bind_kb_{action}={KeyId}` and `bind_gp_{action}={GamepadButtonId}`. No `bind_*` keys in file = use defaults (backward compatible).
-- `io/mod.rs` — Shared menu construction (`build_menu_contents()`), `MenuIds`/`MenuItems` structs, recent ROMs persistence (`~/.config/krankulator/recent_roms.txt`, last 10), platform re-export (`PlatformIOHandler`), `apply_gamepad()` merges keyboard + gamepad state into controllers, `display_width()`/`window_size_for_scale()` helpers for 8:7 PAR viewport calculation
+- `io/mod.rs` — Shared menu construction (`build_menu_contents()`), `MenuIds`/`MenuItems` structs, recent ROMs persistence (`~/.config/krankulator/recent_roms.txt`, last 10), platform re-export (`PlatformIOHandler`), `TurboState` (frame counter for alternating turbo presses), `apply_gamepad()` merges keyboard + gamepad + turbo state into controllers, `display_width()`/`window_size_for_scale()` helpers for 8:7 PAR viewport calculation
 - `io/winit_backend.rs` — macOS/Windows: `WinitPixelsIOHandler` using winit 0.30 + pixels (wgpu), muda menu via `init_for_nsapp()`/`init_for_hwnd()`, CRT shader via `pixels.render_with()` + wgpu render pipeline, debug shell (shrust). Keyboard input routed through `InputBindings` lookup. Binding UI integration via captured key buffer (PollHandler borrows bindings immutably, captured keys processed after handler is dropped).
 - `io/gtk_backend.rs` — Linux: `GtkPixelsIOHandler` using GTK3 + GLArea (OpenGL 3.3 via glow + eglGetProcAddress), muda menu via `init_for_gtk_window()`, native Wayland support. CRT-Lottes-Fast shader (GLSL 3.30, adapted from web ES 3.0 sources). Menu bar hidden in fullscreen. Screensaver/suspend inhibited via D-Bus `org.freedesktop.ScreenSaver.Inhibit`. Keyboard input routed through `InputBindings` lookup. Binding UI state shared via `Rc<Cell<>>` pattern.
 - `audio.rs` — `AudioOutput`: rodio + ringbuf for audio playback
-- `gamepad.rs` — Platform-abstracted gamepad input (GCController on macOS, gilrs on Linux/Windows); Joy-Con pair auto-split into two players; `poll(bindings)` maps physical buttons through configurable `InputBindings` to produce controller bits + edge-detected meta-actions; `poll_raw_buttons()` returns pressed button names for binding UI capture; filters by SdlMappings to avoid misdetected HID devices
+- `gamepad.rs` — Platform-abstracted gamepad input (GCController on macOS, gilrs on Linux/Windows); Joy-Con pair auto-split into two players; reads all 4 face buttons + shoulders + triggers; `poll(bindings)` maps physical buttons through configurable `InputBindings` to produce controller bits, turbo bits + edge-detected meta-actions; `poll_raw_buttons()` returns pressed button names for binding UI capture; filters by SdlMappings to avoid misdetected HID devices
 
 ### Web Frontend (`web/`)
 
@@ -256,16 +256,18 @@ Two macros in `core/src/lib.rs`:
 **Input bindings (desktop)**
 - `InputBindings` maps physical keys/buttons to `Action` enum via linear scan (~40 entries, called per key event not per frame)
 - Keyboard: `KeyId` wraps platform key names (winit `KeyCode` debug names as canonical format, GDK keys mapped to same). `keyboard_action(key)` returns all matching actions.
-- Gamepad: `GamepadButtonId` wraps gilrs `Button` variant names. Physical buttons read into `RawState`, then `pressed_buttons()` iterates as GamepadButtonId names, looked up via `gamepad_action(btn)`.
-- `apply_gamepad()` OR-merges P1/P2 keyboard state with gamepad bits per player into controller bitmask
+- Gamepad: `GamepadButtonId` wraps gilrs `Button` variant names. Physical buttons read into `RawState` (all 4 face buttons + shoulders + triggers), then `pressed_buttons()` iterates as GamepadButtonId names, looked up via `gamepad_action(btn)`.
+- Default gamepad layout: East=A, South=B, North=Turbo A, West=Turbo B, D-Pad, Start/Select, RB=Save, LB=Load, LT=Rewind, RT=Fast Forward
+- `apply_gamepad()` OR-merges P1/P2 keyboard state with gamepad bits per player into controller bitmask, applies turbo toggling (alternates button press every frame via `TurboState`)
 - Gamepad meta-actions (save/load/cycle) use edge detection (trigger on press, not hold)
-- Rewind is level-based (held, not edge-detected)
+- Rewind and fast forward are level-based (held, not edge-detected)
+- Turbo buttons alternate the corresponding NES button every frame (~30Hz at 60fps) while held
 - Binding UI (F10 or Emulation → Input Settings): in-framebuffer overlay drawn on a secondary `Buffer` copy, game renders but controllers zeroed
 - Settings persistence: `bind_kb_{action}={KeyId}`, `bind_gp_{action}={GamepadButtonId}` in settings.txt. No bind keys = defaults.
 
 **Input merging**
 - Multiple input sources (keyboard, touch, gamepad) are OR-merged into a single controller state bitmask each frame
-- Desktop: keyboard state tracked in `kb_state: u8` / `p2_kb_state: u8`, OR'd with gamepad P1/P2 bits, written via `load_status()`
+- Desktop: keyboard state tracked in `kb_state: u8` / `p2_kb_state: u8` + `turbo_kb_state`/`p2_turbo_kb_state`, OR'd with gamepad P1/P2 + turbo bits, written via `load_status()`
 - Web: keyboard/touch keys set OR'd with Gamepad API poll result
 
 ## File Structure
@@ -282,11 +284,11 @@ core/               — Platform-independent emulation library
 desktop/            — Native frontend binary
   src/main.rs       — CLI entry point
   src/debug_ui.rs   — egui debug panels (F12 toggle, disasm + nametables + CPU/PPU/APU + sprites)
-  src/bindings.rs   — Input bindings data model (Action, KeyId, GamepadButtonId, InputBindings)
+  src/bindings.rs   — Input bindings data model (Action incl. turbo variants, KeyId, GamepadButtonId, InputBindings)
   src/bindings_ui.rs — Press-to-bind overlay UI (state machine, framebuffer drawing)
   src/settings.rs   — Persistent settings (integer_scaling, scanlines, overscan, correct_aspect_ratio, window_scale, input bindings)
   src/gamepad.rs    — Platform-abstracted gamepad input (GCController/gilrs), binding-based mapping
-  src/io/mod.rs     — Shared menu, recent ROMs, platform re-export, gamepad merging, PAR/viewport helpers
+  src/io/mod.rs     — Shared menu, recent ROMs, platform re-export, TurboState, gamepad + turbo merging, PAR/viewport helpers
   src/io/winit_backend.rs — macOS/Windows IOHandler (winit + pixels + CRT shader)
   src/io/gtk_backend.rs   — Linux IOHandler (GTK3 + GLArea + glow)
   src/audio.rs      — rodio AudioBackend

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Started as a learning-Rust project — a bare 6502 emulator iterating against th
 - **Audio output** via [rodio](https://github.com/RustAudio/rodio), plus headless capture and WAV export for analysis
 - **Windowed and fullscreen rendering** via [winit](https://github.com/rust-windowing/winit) + [pixels](https://github.com/parasyte/pixels) with integer and fill scaling modes
 - **Configurable input bindings** — rebind keyboard and gamepad buttons via in-game press-to-bind UI (F10 or Emulation → Input Settings); persisted to settings file
+- **Turbo buttons** — A/B turbo (~30 Hz toggle) on gamepad face buttons (Y/X) or rebindable keyboard keys; works for both players
 - **Gamepad support** — GCController on macOS, gilrs on Linux/Windows; two-player with Joy-Con pair auto-split
 - **WebAssembly frontend** — runs in the browser with Canvas 2D rendering, AudioWorklet audio, and touch controls for mobile
 - **RetroArch / libretro core** — load as a core in RetroArch for shaders, netplay, achievements, and universal controller support (Linux x86_64/aarch64, Windows, macOS)
@@ -209,29 +210,49 @@ All keyboard and gamepad bindings are configurable. Press **F10** or use **Emula
 | F10 | Input settings |
 | F11 | Toggle fullscreen |
 | I | Toggle integer/fill scaling |
-| Space | Fast-forward (hold) |
+| Space | Fast forward (hold) |
 | Tab | Toggle frame time overlay |
 | Esc | Quit |
 
 #### Gamepad (auto-detected)
 
-Standard controllers (Pro Controller, Xbox, PS, 8BitDo) use conventional mapping. Joy-Con pair auto-splits into P1 (right) and P2 (left):
+Standard controllers (Pro Controller, Xbox, PS, 8BitDo) use conventional mapping:
+
+| Button | Action |
+|--------|--------|
+| D-pad / Left stick | D-pad |
+| East (B / Circle) | NES A |
+| South (A / Cross) | NES B |
+| North (Y / Triangle) | Turbo A |
+| West (X / Square) | Turbo B |
+| Start | Start |
+| Select / Back | Select |
+| RB (R1) | Save state |
+| LB (L1) | Load state |
+| LT (L2) | Rewind (hold) |
+| RT (R2) | Fast forward (hold) |
+
+Turbo buttons alternate the corresponding NES button press every frame (~30 Hz at 60 fps).
+
+Joy-Con pair auto-splits into P1 (right) and P2 (left):
 
 | Button (P1 right Joy-Con) | Action |
 |---------------------------|--------|
 | Stick | D-pad |
 | Switch X | NES A |
 | Switch B | NES B |
+| Switch A | Turbo A |
+| Switch Y | Turbo B |
 | + | Start |
 | R / ZR | Select |
-| Switch A | Load state |
-| Switch Y | Save state |
 
 | Button (P2 left Joy-Con) | Action |
 |--------------------------|--------|
 | Stick | D-pad |
 | D-pad down | NES A |
 | D-pad left | NES B |
+| D-pad right | Turbo A |
+| D-pad up | Turbo B |
 | - | Start |
 | L / ZL | Select |
 

--- a/TODO.md
+++ b/TODO.md
@@ -258,13 +258,14 @@ Web: keyboard + touch controls (virtual d-pad with deadzone, A/B/Start/Select bu
   - Linux/Windows: gilrs crate with event-based input, SdlMappings filter to avoid misdetected HID devices
   - Web: Gamepad API (navigator.getGamepads()), standard mapping, OR-merged with keyboard/touch
   - Auto-detect connected controllers (up to 2)
-  - D-pad and analog stick mapping (with deadzone)
-  - Two-player support (Joy-Con pair auto-splits into P1/P2)
+  - D-pad and analog stick mapping (with deadzone), all 4 face buttons (A/B + turbo on Y/X)
+  - Two-player support (Joy-Con pair auto-splits into P1/P2, all buttons mapped including turbo)
   - Edge-detected save/load state and slot cycling on P1
+  - Shoulders: RB=save, LB=load. Triggers: LT=rewind, RT=fast forward
   - All platforms: input sources OR-merged so keyboard and gamepad work simultaneously
 - [x] Inhibit screensaver/suspend while running (D-Bus `org.freedesktop.ScreenSaver.Inhibit` via gdbus on Linux) [S]
 - [x] Configurable key/button bindings [M]
-  - `Action` enum (27 variants): P1/P2 NES buttons + system actions (save/load/rewind/mute/etc.)
+  - `Action` enum (33 variants): P1/P2 NES buttons, turbo buttons + system actions (save/load/rewind/mute/etc.)
   - `InputBindings` with separate keyboard (`KeyId`) and gamepad (`GamepadButtonId`) binding vectors
   - Press-to-bind overlay UI: F10 or Emulation → Input Settings menu item
   - In-framebuffer overlay using 8x8 font, state machine (SelectAction → ActionMenu → WaitingForInput)
@@ -272,7 +273,7 @@ Web: keyboard + touch controls (virtual d-pad with deadzone, A/B/Start/Select bu
   - Two-player keyboard support (P2 bindings assignable, no defaults)
   - Desktop only (web/libretro excluded — libretro has its own remapping, web can follow later)
 - [ ] Per-controller gamepad profiles [S]
-- [ ] Turbo A/B buttons (optional toggle) [XS]
+- [x] Turbo A/B buttons (~30 Hz toggle, gamepad North/West default, P1+P2, keyboard rebindable) [XS]
 
 ---
 
@@ -314,8 +315,8 @@ Web: keyboard + touch controls (virtual d-pad with deadzone, A/B/Start/Select bu
 
 ## Emulation Features
 
-- [x] Rewind (hold W or right trigger to scrub back through 10s of gameplay at 2x speed) [L]
-- [x] Fast-forward (hold Space for uncapped speed) [S]
+- [x] Rewind (hold W or LT to scrub back through 10s of gameplay at 2x speed) [L]
+- [x] Fast forward (hold Space or RT for uncapped speed) [S]
 - [ ] Slow-motion (0.5x speed toggle) [XS]
 - [ ] Screenshot (save framebuffer as PNG) [S]
 - [ ] Video recording (save to GIF or MP4) [L]

--- a/desktop/src/bindings/data.rs
+++ b/desktop/src/bindings/data.rs
@@ -18,6 +18,10 @@ pub enum Action {
     P2Down,
     P2Left,
     P2Right,
+    P1TurboA,
+    P1TurboB,
+    P2TurboA,
+    P2TurboB,
     SaveState,
     LoadState,
     CycleSlot,
@@ -52,6 +56,10 @@ impl Action {
             Action::P2Down => "p2_down",
             Action::P2Left => "p2_left",
             Action::P2Right => "p2_right",
+            Action::P1TurboA => "p1_turbo_a",
+            Action::P1TurboB => "p1_turbo_b",
+            Action::P2TurboA => "p2_turbo_a",
+            Action::P2TurboB => "p2_turbo_b",
             Action::SaveState => "save_state",
             Action::LoadState => "load_state",
             Action::CycleSlot => "cycle_slot",
@@ -86,6 +94,10 @@ impl Action {
             "p2_down" => Some(Action::P2Down),
             "p2_left" => Some(Action::P2Left),
             "p2_right" => Some(Action::P2Right),
+            "p1_turbo_a" => Some(Action::P1TurboA),
+            "p1_turbo_b" => Some(Action::P1TurboB),
+            "p2_turbo_a" => Some(Action::P2TurboA),
+            "p2_turbo_b" => Some(Action::P2TurboB),
             "save_state" => Some(Action::SaveState),
             "load_state" => Some(Action::LoadState),
             "cycle_slot" => Some(Action::CycleSlot),
@@ -121,6 +133,10 @@ impl Action {
             Action::P2Down => "P2 Down",
             Action::P2Left => "P2 Left",
             Action::P2Right => "P2 Right",
+            Action::P1TurboA => "P1 Turbo A",
+            Action::P1TurboB => "P1 Turbo B",
+            Action::P2TurboA => "P2 Turbo A",
+            Action::P2TurboB => "P2 Turbo B",
             Action::SaveState => "Save State",
             Action::LoadState => "Load State",
             Action::CycleSlot => "Cycle Slot",
@@ -159,6 +175,16 @@ impl Action {
         }
     }
 
+    pub fn turbo_controller_bit(self) -> Option<(u8, u8)> {
+        match self {
+            Action::P1TurboA => Some((0, controller::A)),
+            Action::P1TurboB => Some((0, controller::B)),
+            Action::P2TurboA => Some((1, controller::A)),
+            Action::P2TurboB => Some((1, controller::B)),
+            _ => None,
+        }
+    }
+
     pub const ALL: &'static [Action] = &[
         Action::P1A,
         Action::P1B,
@@ -176,6 +202,10 @@ impl Action {
         Action::P2Down,
         Action::P2Left,
         Action::P2Right,
+        Action::P1TurboA,
+        Action::P1TurboB,
+        Action::P2TurboA,
+        Action::P2TurboB,
         Action::SaveState,
         Action::LoadState,
         Action::CycleSlot,
@@ -346,6 +376,8 @@ impl Default for InputBindings {
             gamepad: vec![
                 (GamepadButtonId("East".into()), Action::P1A),
                 (GamepadButtonId("South".into()), Action::P1B),
+                (GamepadButtonId("North".into()), Action::P1TurboA),
+                (GamepadButtonId("West".into()), Action::P1TurboB),
                 (GamepadButtonId("Start".into()), Action::P1Start),
                 (GamepadButtonId("Select".into()), Action::P1Select),
                 (GamepadButtonId("DPadUp".into()), Action::P1Up),
@@ -354,8 +386,8 @@ impl Default for InputBindings {
                 (GamepadButtonId("DPadRight".into()), Action::P1Right),
                 (GamepadButtonId("RightTrigger".into()), Action::SaveState),
                 (GamepadButtonId("LeftTrigger".into()), Action::LoadState),
-                (GamepadButtonId("LeftTrigger2".into()), Action::CycleSlot),
-                (GamepadButtonId("RightTrigger2".into()), Action::Rewind),
+                (GamepadButtonId("LeftTrigger2".into()), Action::Rewind),
+                (GamepadButtonId("RightTrigger2".into()), Action::FastForward),
             ],
         }
     }

--- a/desktop/src/gamepad.rs
+++ b/desktop/src/gamepad.rs
@@ -3,16 +3,21 @@ use crate::bindings::{Action, InputBindings};
 pub struct GamepadState {
     pub p1_bits: u8,
     pub p2_bits: u8,
+    pub turbo_p1_bits: u8,
+    pub turbo_p2_bits: u8,
     pub save_state: bool,
     pub load_state: bool,
     pub cycle_slot: bool,
     pub rewind: bool,
+    pub fast_forward: bool,
 }
 
 #[derive(Default)]
 struct RawState {
     a: bool,
     b: bool,
+    north: bool,
+    west: bool,
     start: bool,
     select: bool,
     up: bool,
@@ -30,6 +35,8 @@ impl RawState {
         [
             (self.a, "East"),
             (self.b, "South"),
+            (self.north, "North"),
+            (self.west, "West"),
             (self.start, "Start"),
             (self.select, "Select"),
             (self.up, "DPadUp"),
@@ -109,15 +116,17 @@ impl Gamepads {
             if let Some(s) = state {
                 let mut p1_bits: u8 = 0;
                 let mut p2_bits: u8 = 0;
+                let mut turbo_p1_bits: u8 = 0;
+                let mut turbo_p2_bits: u8 = 0;
                 let mut save_raw = false;
                 let mut load_raw = false;
                 let mut cycle_raw = false;
                 let mut rewind = false;
+                let mut fast_forward = false;
 
                 for btn_name in s.pressed_buttons() {
                     for action in bindings.gamepad_action(btn_name) {
                         if let Some((player, bit)) = action.controller_bit() {
-                            // Gamepad slot offsets the player: P1 actions on gamepad 1 go to P2
                             let effective = (player as usize + i) % 2;
                             if effective == 0 {
                                 p1_bits |= bit;
@@ -125,11 +134,20 @@ impl Gamepads {
                                 p2_bits |= bit;
                             }
                         }
+                        if let Some((player, bit)) = action.turbo_controller_bit() {
+                            let effective = (player as usize + i) % 2;
+                            if effective == 0 {
+                                turbo_p1_bits |= bit;
+                            } else {
+                                turbo_p2_bits |= bit;
+                            }
+                        }
                         match action {
                             Action::SaveState => save_raw = true,
                             Action::LoadState => load_raw = true,
                             Action::CycleSlot => cycle_raw = true,
                             Action::Rewind => rewind = true,
+                            Action::FastForward => fast_forward = true,
                             _ => {}
                         }
                     }
@@ -146,10 +164,13 @@ impl Gamepads {
                 states[i] = Some(GamepadState {
                     p1_bits,
                     p2_bits,
+                    turbo_p1_bits,
+                    turbo_p2_bits,
                     save_state: save_edge,
                     load_state: load_edge,
                     cycle_slot: cycle_edge,
                     rewind,
+                    fast_forward,
                 });
             }
         }
@@ -206,10 +227,12 @@ mod platform {
                             right: ry < -0.5,
                             a: sw_x,
                             b: sw_b,
+                            north: sw_a,
+                            west: sw_y,
                             start: gamepad.buttonMenu().isPressed(),
                             select: r_sh || r_tr,
-                            left_shoulder: sw_a,
-                            right_shoulder: sw_y,
+                            left_shoulder: false,
+                            right_shoulder: false,
                             left_trigger: false,
                             right_trigger: false,
                         });
@@ -227,6 +250,8 @@ mod platform {
                             right: ly < -0.5,
                             a: dpad.down().isPressed(),
                             b: dpad.left().isPressed(),
+                            north: dpad.right().isPressed(),
+                            west: dpad.up().isPressed(),
                             start: gamepad.buttonOptions().is_some_and(|b| b.isPressed()),
                             select: l_sh || l_tr,
                             left_shoulder: false,
@@ -245,6 +270,8 @@ mod platform {
                         result[slot] = Some(RawState {
                             a: gamepad.buttonB().isPressed(),
                             b: gamepad.buttonA().isPressed(),
+                            north: gamepad.buttonY().isPressed(),
+                            west: gamepad.buttonX().isPressed(),
                             start: gamepad.buttonMenu().isPressed(),
                             select: gamepad.buttonOptions().is_some_and(|b| b.isPressed()),
                             up: dpad.up().isPressed() || ly > 0.5,
@@ -359,6 +386,8 @@ mod platform {
                     result[i] = Some(RawState {
                         a: s.a,
                         b: s.b,
+                        north: s.north,
+                        west: s.west,
                         start: s.start,
                         select: s.select,
                         up: s.up,
@@ -381,6 +410,8 @@ mod platform {
             match btn {
                 Button::East => s.a = pressed,
                 Button::South => s.b = pressed,
+                Button::North => s.north = pressed,
+                Button::West => s.west = pressed,
                 Button::Start => s.start = pressed,
                 Button::Select => s.select = pressed,
                 Button::DPadUp => s.up = pressed,

--- a/desktop/src/io/gtk_backend.rs
+++ b/desktop/src/io/gtk_backend.rs
@@ -21,7 +21,7 @@ use crate::debug::{DebugUi, PANEL_WIDTH};
 
 use super::{
     add_recent_rom, apply_gamepad, build_menu_contents, display_width, frame_pace, open_rom_dialog,
-    populate_recent_submenu, window_size_for_scale, MenuIds, MenuItems, NES_TEX_HEIGHT,
+    populate_recent_submenu, window_size_for_scale, MenuIds, MenuItems, TurboState, NES_TEX_HEIGHT,
     NTSC_FRAME_DURATION,
 };
 use crate::bindings::ui::{BindingUi, UiEvent};
@@ -123,6 +123,9 @@ pub struct GtkPixelsIOHandler {
     frame_duration: Duration,
     kb_state: Rc<Cell<u8>>,
     p2_kb_state: Rc<Cell<u8>>,
+    turbo_kb_state: Rc<Cell<u8>>,
+    p2_turbo_kb_state: Rc<Cell<u8>>,
+    turbo: TurboState,
     fast_forward: Rc<Cell<bool>>,
     pixel_perfect: Rc<Cell<bool>>,
     scanlines: Rc<Cell<bool>>,
@@ -271,6 +274,8 @@ impl GtkPixelsIOHandler {
         let exit_flag = Rc::new(Cell::new(false));
         let kb_state = Rc::new(Cell::new(0u8));
         let p2_kb_state = Rc::new(Cell::new(0u8));
+        let turbo_kb_state = Rc::new(Cell::new(0u8));
+        let p2_turbo_kb_state = Rc::new(Cell::new(0u8));
         let fast_forward = Rc::new(Cell::new(false));
         let muted = Rc::new(Cell::new(false));
         let save_state_flag = Rc::new(Cell::new(false));
@@ -300,6 +305,8 @@ impl GtkPixelsIOHandler {
         {
             let kb = kb_state.clone();
             let p2kb = p2_kb_state.clone();
+            let tkb = turbo_kb_state.clone();
+            let p2tkb = p2_turbo_kb_state.clone();
             let ff = fast_forward.clone();
             let mt = muted.clone();
             let save = save_state_flag.clone();
@@ -332,8 +339,8 @@ impl GtkPixelsIOHandler {
                     return glib::Propagation::Proceed;
                 }
                 handle_key(
-                    event, true, &kb, &p2kb, &ff, &mt, &save, &load, &cycle, &reset, &overlay, &rw,
-                    &fs, &ex, &pp, &sl, &car, &su, &sd, &bi, &td, &tp,
+                    event, true, &kb, &p2kb, &tkb, &p2tkb, &ff, &mt, &save, &load, &cycle, &reset,
+                    &overlay, &rw, &fs, &ex, &pp, &sl, &car, &su, &sd, &bi, &td, &tp,
                 );
                 glib::Propagation::Proceed
             });
@@ -342,6 +349,8 @@ impl GtkPixelsIOHandler {
         {
             let kb = kb_state.clone();
             let p2kb = p2_kb_state.clone();
+            let tkb = turbo_kb_state.clone();
+            let p2tkb = p2_turbo_kb_state.clone();
             let ff = fast_forward.clone();
             let mt = muted.clone();
             let save = save_state_flag.clone();
@@ -366,8 +375,8 @@ impl GtkPixelsIOHandler {
                     return glib::Propagation::Proceed;
                 }
                 handle_key(
-                    event, false, &kb, &p2kb, &ff, &mt, &save, &load, &cycle, &reset, &overlay,
-                    &rw, &fs, &ex, &pp, &sl, &car, &su, &sd, &bi, &td, &tp,
+                    event, false, &kb, &p2kb, &tkb, &p2tkb, &ff, &mt, &save, &load, &cycle, &reset,
+                    &overlay, &rw, &fs, &ex, &pp, &sl, &car, &su, &sd, &bi, &td, &tp,
                 );
                 glib::Propagation::Proceed
             });
@@ -392,6 +401,9 @@ impl GtkPixelsIOHandler {
             frame_duration: NTSC_FRAME_DURATION,
             kb_state,
             p2_kb_state,
+            turbo_kb_state,
+            p2_turbo_kb_state,
+            turbo: TurboState::new(),
             fast_forward,
             pixel_perfect,
             scanlines,
@@ -656,6 +668,8 @@ fn handle_key(
     pressed: bool,
     kb_state: &Rc<Cell<u8>>,
     p2_kb_state: &Rc<Cell<u8>>,
+    turbo_kb_state: &Rc<Cell<u8>>,
+    p2_turbo_kb_state: &Rc<Cell<u8>>,
     fast_forward: &Rc<Cell<bool>>,
     muted: &Rc<Cell<bool>>,
     save_state: &Rc<Cell<bool>>,
@@ -696,8 +710,23 @@ fn handle_key(
     let bindings = bindings.borrow();
     let mut p1_kb = kb_state.get();
     let mut p2_kb = p2_kb_state.get();
+    let mut p1_turbo = turbo_kb_state.get();
+    let mut p2_turbo = p2_turbo_kb_state.get();
 
     for action in bindings.keyboard_action(&key_id) {
+        if let Some((player, bit)) = action.turbo_controller_bit() {
+            let state = if player == 0 {
+                &mut p1_turbo
+            } else {
+                &mut p2_turbo
+            };
+            if pressed {
+                *state |= bit;
+            } else {
+                *state &= !bit;
+            }
+            continue;
+        }
         match action {
             Action::Fullscreen => {
                 if pressed {
@@ -779,6 +808,8 @@ fn handle_key(
 
     kb_state.set(p1_kb);
     p2_kb_state.set(p2_kb);
+    turbo_kb_state.set(p1_turbo);
+    p2_turbo_kb_state.set(p2_turbo);
 }
 
 impl IOHandler for GtkPixelsIOHandler {
@@ -1118,6 +1149,9 @@ impl IOHandler for GtkPixelsIOHandler {
                 &self.bindings.borrow(),
                 self.kb_state.get(),
                 self.p2_kb_state.get(),
+                self.turbo_kb_state.get(),
+                self.p2_turbo_kb_state.get(),
+                &mut self.turbo,
                 mem,
                 &mut result,
             );

--- a/desktop/src/io/mod.rs
+++ b/desktop/src/io/mod.rs
@@ -319,11 +319,32 @@ pub(crate) fn open_rom_dialog() -> Option<String> {
     })
 }
 
+pub struct TurboState {
+    frame_counter: u8,
+}
+
+impl TurboState {
+    pub fn new() -> Self {
+        Self { frame_counter: 0 }
+    }
+
+    fn tick(&mut self) {
+        self.frame_counter = self.frame_counter.wrapping_add(1);
+    }
+
+    fn is_active(&self) -> bool {
+        self.frame_counter % 2 == 0
+    }
+}
+
 pub(crate) fn apply_gamepad(
     gamepads: &mut Gamepads,
     bindings: &InputBindings,
     p1_kb_state: u8,
     p2_kb_state: u8,
+    p1_turbo_kb: u8,
+    p2_turbo_kb: u8,
+    turbo: &mut TurboState,
     mem: &mut dyn memory::MemoryMapper,
     result: &mut PollResult,
 ) {
@@ -334,10 +355,14 @@ pub(crate) fn apply_gamepad(
 
     let mut p0_state = p1_kb_state;
     let mut p1_state = p2_kb_state;
+    let mut turbo_p0: u8 = p1_turbo_kb;
+    let mut turbo_p1: u8 = p2_turbo_kb;
 
-    if let Some(s) = &gp.states[0] {
+    for s in gp.states.iter().flatten() {
         p0_state |= s.p1_bits;
         p1_state |= s.p2_bits;
+        turbo_p0 |= s.turbo_p1_bits;
+        turbo_p1 |= s.turbo_p2_bits;
         if s.save_state {
             result.save_state = true;
         }
@@ -350,23 +375,16 @@ pub(crate) fn apply_gamepad(
         if s.rewind {
             result.rewind = true;
         }
-    }
-    if let Some(s) = &gp.states[1] {
-        p0_state |= s.p1_bits;
-        p1_state |= s.p2_bits;
-        if s.save_state {
-            result.save_state = true;
-        }
-        if s.load_state {
-            result.load_state = true;
-        }
-        if s.cycle_slot {
-            result.cycle_slot = true;
-        }
-        if s.rewind {
-            result.rewind = true;
+        if s.fast_forward {
+            result.fast_forward = true;
         }
     }
+
+    if turbo.is_active() {
+        p0_state |= turbo_p0;
+        p1_state |= turbo_p1;
+    }
+    turbo.tick();
 
     mem.controllers()[0].load_status(p0_state);
     mem.controllers()[1].load_status(p1_state);

--- a/desktop/src/io/winit_backend.rs
+++ b/desktop/src/io/winit_backend.rs
@@ -25,7 +25,7 @@ use crate::debug::DebugUi;
 
 use super::{
     add_recent_rom, apply_gamepad, build_menu_contents, display_width, frame_pace, open_rom_dialog,
-    populate_recent_submenu, window_size_for_scale, MenuIds, MenuItems, NES_TEX_HEIGHT,
+    populate_recent_submenu, window_size_for_scale, MenuIds, MenuItems, TurboState, NES_TEX_HEIGHT,
     NES_TEX_WIDTH, NTSC_FRAME_DURATION,
 };
 use crate::bindings::ui::{BindingUi, UiEvent};
@@ -60,6 +60,9 @@ pub struct WinitPixelsIOHandler {
     last_frame_ms: f64,
     kb_state: u8,
     p2_kb_state: u8,
+    turbo_kb_state: u8,
+    p2_turbo_kb_state: u8,
+    turbo: TurboState,
     fast_forward: bool,
     pixel_perfect: bool,
     rewind_held: bool,
@@ -186,6 +189,9 @@ impl WinitPixelsIOHandler {
             last_frame_ms: 0.0,
             kb_state: 0,
             p2_kb_state: 0,
+            turbo_kb_state: 0,
+            p2_turbo_kb_state: 0,
+            turbo: TurboState::new(),
             fast_forward: false,
             pixel_perfect: settings.integer_scaling,
             rewind_held: false,
@@ -381,6 +387,8 @@ struct PollHandler<'a> {
     overscan_changed: bool,
     kb_state: &'a mut u8,
     p2_kb_state: &'a mut u8,
+    turbo_kb_state: &'a mut u8,
+    p2_turbo_kb_state: &'a mut u8,
     fast_forward: &'a mut bool,
     exit: bool,
     save_state: bool,
@@ -459,6 +467,19 @@ impl ApplicationHandler for PollHandler<'_> {
                     }
 
                     for action in self.bindings.keyboard_action(&key_id) {
+                        if let Some((player, bit)) = action.turbo_controller_bit() {
+                            let state = if player == 0 {
+                                &mut *self.turbo_kb_state
+                            } else {
+                                &mut *self.p2_turbo_kb_state
+                            };
+                            if pressed {
+                                *state |= bit;
+                            } else {
+                                *state &= !bit;
+                            }
+                            continue;
+                        }
                         match action {
                             Action::Fullscreen => {
                                 if pressed {
@@ -639,6 +660,8 @@ impl IOHandler for WinitPixelsIOHandler {
             overscan_changed: false,
             kb_state: &mut self.kb_state,
             p2_kb_state: &mut self.p2_kb_state,
+            turbo_kb_state: &mut self.turbo_kb_state,
+            p2_turbo_kb_state: &mut self.p2_turbo_kb_state,
             fast_forward: &mut self.fast_forward,
             exit: false,
             save_state: false,
@@ -906,6 +929,9 @@ impl IOHandler for WinitPixelsIOHandler {
                 &self.bindings,
                 self.kb_state,
                 self.p2_kb_state,
+                self.turbo_kb_state,
+                self.p2_turbo_kb_state,
+                &mut self.turbo,
                 mem,
                 &mut result,
             );


### PR DESCRIPTION
## Summary
- Implement turbo A/B buttons that alternate the NES button press every frame (~30 Hz) while held
- Revise default gamepad layout: North=Turbo A, West=Turbo B, LT=Rewind, RT=Fast Forward
- Save/Load state remain on RB/LB; Cycle Slot removed from gamepad defaults
- All platforms updated: gilrs, GCController, and Joy-Con pairs now read all 4 face buttons

## Test plan
- [x] Verify turbo A/B toggles rapidly in a game (e.g. rapid fire in a shooter)
- [x] Verify regular A/B still works normally on East/South buttons
- [x] Verify rewind works on LT, fast forward on RT
- [x] Verify save/load state still works on RB/LB
- [x] Verify turbo works from keyboard when rebound via F10 settings
- [ ] Verify Joy-Con pair maps turbo buttons correctly
- [ ] Run `cargo test -p krankulator-desktop` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)